### PR TITLE
Say hello

### DIFF
--- a/working code as of july 22nd.html
+++ b/working code as of july 22nd.html
@@ -2350,7 +2350,7 @@ jQuery(document).ready(function($) {
         var xt4DescriptionsUrl = 'https://hutchinsonautoteam.com/cadillacmodels/cadillacxt4descriptions.csv';
         console.log('Loading Cadillac XT4 feature descriptions from:', xt4DescriptionsUrl);
         
-        fetch(xt4DescriptionsUrl)
+        return fetch(xt4DescriptionsUrl)
         .then(function(response) {
             if (!response.ok) {
                 throw new Error('Network response was not ok: ' + response.status);
@@ -6716,7 +6716,16 @@ function populateXT4Features() {
     console.log('XT4 HTML block found:', htmlBlock.attr('id'));
     console.log('XT4 CSV URL:', config.csvUrl);
 
-    return fetchCsvWithRetry(config.csvUrl, 'XT4 CSV', 3, 1000).then(function(csvText) {
+    // Load XT4 descriptions first
+    var descriptionsUrl = descriptionUrlMap['XT4'];
+    console.log('XT4 descriptions URL:', descriptionsUrl);
+    
+    return loadXT4FeatureDescriptions().then(function() {
+        console.log('✅ XT4 descriptions loaded successfully');
+        console.log('XT4 descriptions count:', Object.keys(window.xt4FeatureDescriptions || {}).length);
+        
+        return fetchCsvWithRetry(config.csvUrl, 'XT4 CSV', 3, 1000);
+    }).then(function(csvText) {
         console.log('XT4 CSV fetched successfully, length:', csvText.length, 'characters');
         console.log('XT4 CSV first 200 chars:', csvText.substring(0, 200));
         console.log('XT4 CSV first line:', csvText.split('\n')[0]);

--- a/working code as of july 22nd.html
+++ b/working code as of july 22nd.html
@@ -6653,10 +6653,11 @@ function populateXT4Features() {
     return fetchCsvWithRetry(config.csvUrl, 'XT4 CSV', 3, 1000).then(function(csvText) {
         console.log('XT4 CSV fetched successfully, length:', csvText.length, 'characters, first 100 chars:', csvText.substring(0, 100));
 
-        Papa.parse(csvText, {
-            header: false,
-            skipEmptyLines: true,
-            complete: function(results) {
+        return new Promise(function(resolve, reject) {
+            Papa.parse(csvText, {
+                header: false,
+                skipEmptyLines: true,
+                complete: function(results) {
                 console.log('XT4 CSV parsed, rows:', results.data.length);
                 console.log('First 10 rows of parsed data:', results.data.slice(0, 10));
 
@@ -6819,13 +6820,18 @@ function populateXT4Features() {
                     var description = getFeatureDescription(feature, 'XT4');
                     showFeatureDescription(feature, description);
                 });
-            },
-            error: function(error) {
-                console.error('Papa Parse error for XT4 population: ' + error);
-            }
+                
+                resolve();
+                },
+                error: function(error) {
+                    console.error('Papa Parse error for XT4 population: ' + error);
+                    reject(error);
+                }
+            });
         });
     }).catch(function(error) {
         console.error('Fetch error for XT4 population: ' + error.message);
+        return Promise.reject(error);
     });
 }
 
@@ -16008,7 +16014,9 @@ $(document).on('change', 'input[type="radio"]', function() {
         }).catch(function(error) {
             console.error('❌ ESCALADE ESV population failed from global listener:', error);
         });
-    } else if ($(this).val() === 'XT4' && $(this).is(':checked')) {
+    }
+    
+    if ($(this).val() === 'XT4' && $(this).is(':checked')) {
         console.log('🚨 XT4 DETECTED IN GLOBAL LISTENER - FORCING POPULATE');
         xt4Populated = false;
         populateXT4Features().then(function() {

--- a/working code as of july 22nd.html
+++ b/working code as of july 22nd.html
@@ -6654,7 +6654,7 @@ function populateXT4Features() {
     var descriptionsUrl = descriptionUrlMap['XT4'];
     console.log('XT4 descriptions URL:', descriptionsUrl);
     
-    return loadFeatureDescriptions('XT4', descriptionsUrl).then(function() {
+    return loadModelDescriptions('XT4', descriptionsUrl).then(function() {
         console.log('✅ XT4 descriptions loaded successfully');
         console.log('XT4 descriptions count:', Object.keys(window.xt4FeatureDescriptions || {}).length);
         console.log('XT4 descriptions sample:', Object.keys(window.xt4FeatureDescriptions || {}).slice(0, 5));

--- a/working code as of july 22nd.html
+++ b/working code as of july 22nd.html
@@ -690,6 +690,12 @@ jQuery(document).ready(function($) {
             margin-bottom: 4% !important;
             padding-bottom: 4px;
         }
+        
+        /* Cadillac Escalade ESV checkbox spacing */
+        .gchoice[class*="gchoice_escaladeesv_"] {
+            margin-bottom: 4% !important;
+            padding-bottom: 4px;
+        }
         /* Trim levels left alignment - force override any parent centering */
         .trim-levels-display {
             text-align: left !important;
@@ -920,6 +926,10 @@ jQuery(document).ready(function($) {
     // Cadillac Escalade Model Field IDs
     var escaladeCheckboxFieldId = 153;
     var escaladeHtmlBlockFieldId = 153;
+    
+    // Cadillac Escalade ESV Model Field IDs
+    var escaladeESVCheckboxFieldId = 154;
+    var escaladeESVHtmlBlockFieldId = 154;
 
     /*
     📋 STEP 1B: POPULATED FLAGS - Add your model's populated flag here
@@ -948,6 +958,7 @@ jQuery(document).ready(function($) {
     var ct5Populated = false;
     var ct5VSeriesPopulated = false;
     var escaladePopulated = false;
+    var escaladeESVPopulated = false;
     
     // Function to find best description match with fuzzy matching for typos
     function findBestDescriptionMatch(searchFeature, descriptionMap) {
@@ -1139,7 +1150,8 @@ jQuery(document).ready(function($) {
         'CT4 V-SERIES': { fieldId: ct4VSeriesCheckboxFieldId, csvUrl: 'https://hutchinsonautoteam.com/cadillacmodels/ct4v.csv', modelFilter: 'CT4', isCadillac: true },
         'CT5': { fieldId: ct5CheckboxFieldId, csvUrl: 'https://hutchinsonautoteam.com/cadillacmodels/ct5.csv', modelFilter: 'CT5', isCadillac: true },
         'CT5 V-SERIES': { fieldId: ct5VSeriesCheckboxFieldId, csvUrl: 'https://hutchinsonautoteam.com/cadillacmodels/ct5v.csv', modelFilter: 'CT5', isCadillac: true },
-        'Escalade': { fieldId: escaladeCheckboxFieldId, csvUrl: 'https://hutchinsonautoteam.com/cadillacmodels/escalade.csv', modelFilter: 'Escalade', isCadillac: true }
+        'Escalade': { fieldId: escaladeCheckboxFieldId, csvUrl: 'https://hutchinsonautoteam.com/cadillacmodels/escalade.csv', modelFilter: 'Escalade', isCadillac: true },
+        'Escalade ESV': { fieldId: escaladeESVCheckboxFieldId, csvUrl: 'https://hutchinsonautoteam.com/cadillacmodels/escaladeesv.csv', modelFilter: 'Escalade ESV', isCadillac: true }
     };
 
     // Email mappings
@@ -1480,6 +1492,9 @@ jQuery(document).ready(function($) {
     // Global variable for Cadillac Escalade feature descriptions
     window.escaladeFeatureDescriptions = {};
     
+    // Global variable for Cadillac Escalade ESV feature descriptions
+    window.escaladeESVFeatureDescriptions = {};
+    
     // ============================================================================
     // FUTURE-PROOF DESCRIPTION SYSTEM
     // ============================================================================
@@ -1516,6 +1531,7 @@ jQuery(document).ready(function($) {
         'CT5': 'https://hutchinsonautoteam.com/cadillacmodels/cadillacct5descriptions.csv',
         'CT5 V-SERIES': 'https://hutchinsonautoteam.com/cadillacmodels/cadillacct5vdescriptions.csv',
         'Escalade': 'https://hutchinsonautoteam.com/cadillacmodels/cadillacescaladedescriptions.csv',
+        'Escalade ESV': 'https://hutchinsonautoteam.com/cadillacmodels/cadillacescaladeesvdescriptions.csv',
         
         // Kia Models (using generic pattern - can be customized per model)
         'K4': 'https://hutchinsonautoteam.com/kiamodels/KIAMODELDESCRIPTIONS.CSV',
@@ -1637,6 +1653,9 @@ jQuery(document).ready(function($) {
                 break;
             case 'Escalade':
                 window.escaladeFeatureDescriptions[featureUpper] = description;
+                break;
+            case 'Escalade ESV':
+                window.escaladeESVFeatureDescriptions[featureUpper] = description;
                 break;
         }
     }
@@ -6213,6 +6232,253 @@ function populateEscaladeFeatures() {
     });
 }
 
+// Cadillac Escalade ESV population function
+function populateEscaladeESVFeatures() {
+    console.log('=== populateEscaladeESVFeatures called ===');
+    console.log('Current escaladeESVPopulated flag:', escaladeESVPopulated);
+    console.log('Form ID:', formId);
+    console.log('escaladeESVHtmlBlockFieldId:', escaladeESVHtmlBlockFieldId);
+    
+    if (escaladeESVPopulated) {
+        console.log('Escalade ESV features already populated, skipping');
+        return Promise.resolve();
+    }
+
+    var config = modelConfigs['Escalade ESV'];
+    if (!config) {
+        console.warn('Escalade ESV configuration not found');
+        console.log('Available modelConfigs:', Object.keys(modelConfigs));
+        return Promise.reject(new Error('Escalade ESV configuration not found'));
+    }
+    console.log('Escalade ESV config found:', config);
+
+    // Try multiple selectors to find the HTML block field
+    console.log('Searching for HTML block field with multiple selectors...');
+    var htmlBlock = $('#field_' + formId + '_' + escaladeESVHtmlBlockFieldId);
+    console.log('Selector 1 (#field_' + formId + '_' + escaladeESVHtmlBlockFieldId + '):', htmlBlock.length);
+    
+    if (!htmlBlock.length) {
+        htmlBlock = $('#field_' + formId + '_154');
+        console.log('Selector 2 (#field_' + formId + '_154):', htmlBlock.length);
+    }
+    if (!htmlBlock.length) {
+        htmlBlock = $('#input_' + formId + '_154');
+        console.log('Selector 3 (#input_' + formId + '_154):', htmlBlock.length);
+    }
+    if (!htmlBlock.length) {
+        htmlBlock = $('[id*="154"]').filter(function() {
+            return $(this).attr('id').includes('field') || $(this).attr('id').includes('input');
+        });
+        console.log('Selector 4 (wildcard [id*="154"]):', htmlBlock.length);
+    }
+    
+    console.log('HTML Block field (ID: 154) debug:', {
+        selector: '#field_' + formId + '_' + escaladeESVHtmlBlockFieldId,
+        exists: htmlBlock.length > 0,
+        visible: htmlBlock.length ? htmlBlock.is(':visible') : false,
+        content: htmlBlock.length ? htmlBlock.html().substring(0, 200) : 'N/A',
+        actualId: htmlBlock.length ? htmlBlock.attr('id') : 'N/A'
+    });
+    
+    if (!htmlBlock.length) {
+        console.warn('Escalade ESV HTML block field (ID: 154) not found');
+        return Promise.reject(new Error('Escalade ESV HTML block field not found'));
+    }
+
+    console.log('Fetching Escalade ESV CSV from:', config.csvUrl);
+    return fetchCsvWithRetry(config.csvUrl, 'Escalade ESV', 3, 1000).then(function(csvText) {
+        console.log('Escalade ESV CSV fetched successfully, length:', csvText.length);
+        console.log('CSV preview (first 500 chars):', csvText.substring(0, 500));
+        
+        Papa.parse(csvText, {
+            skipEmptyLines: true,
+            complete: function(results) {
+                console.log('Escalade ESV CSV parsed for population, rows: ' + results.data.length);
+                console.log('First few rows:', results.data.slice(0, 3));
+                
+                var categories = ['EXTERIOR', 'INTERIOR', 'MECHANICAL', 'SAFETY', 'PACKAGES'];
+                var featureGroups = {};
+                var currentCategory = null;
+                var features = [];
+
+                results.data.forEach(function(row, rowIndex) {
+                    if (row.length > 0) {
+                        var firstCell = row[0] ? row[0].trim() : '';
+                        if (firstCell.startsWith('TRIM LEVELS FOR {')) {
+                            if (currentCategory && features.length > 0) {
+                                featureGroups[currentCategory] = features;
+                                console.log('Stored category: ' + currentCategory + ' with ' + features.length + ' features');
+                            }
+                            currentCategory = firstCell.match(/\{(.+)\}/)[1];
+                            // Clean up features by removing extra quotes and trimming
+                            features = row.slice(1).filter(function(f) { return f && f.trim() !== ''; }).map(function(f) {
+                                // Remove surrounding quotes if present
+                                var cleaned = f.trim();
+                                if (cleaned.startsWith('"') && cleaned.endsWith('"')) {
+                                    cleaned = cleaned.slice(1, -1);
+                                }
+                                // Handle double quotes inside the string (CSV escape format)
+                                cleaned = cleaned.replace(/""/g, '"');
+                                return cleaned;
+                            });
+                            console.log('Row ' + rowIndex + ': Parsed category: ' + currentCategory + ', features: ' + features.length);
+                            console.log('Features for ' + currentCategory + ':', features.slice(0, 5)); // Show first 5 features
+                            console.log('Raw features before cleaning:', row.slice(1, 6)); // Show raw features
+                        }
+                    }
+                });
+                if (currentCategory && features.length > 0) {
+                    featureGroups[currentCategory] = features;
+                    console.log('Final stored category: ' + currentCategory + ' with ' + features.length + ' features');
+                }
+
+                console.log('Feature groups summary:', Object.keys(featureGroups).map(function(cat) {
+                    return cat + ': ' + featureGroups[cat].length + ' features';
+                }));
+
+                if (Object.keys(featureGroups).length !== 5) {
+                    console.error('Expected 5 categories, found: ' + Object.keys(featureGroups).length);
+                    console.error('Found categories:', Object.keys(featureGroups));
+                    return;
+                }
+
+                // Populate trim level mapping from CSV data before building checkboxes
+                console.log('Populating trim level mapping for Escalade ESV features...');
+                var trimLevels = discoverTrimLevelsFromCSV(results.data, categories);
+                var featureToColumnMap = {};
+                var featureToCategoryMap = {};
+                var trimLevelRowsByCategory = {};
+                
+                // Parse CSV data to create feature-to-column mapping and find trim level data (Cadillac structure like Sierra)
+                var currentCategory = null;
+                results.data.forEach(function(row, rowIndex) {
+                    if (row && row.length > 0) {
+                        var firstCell = row[0];
+                        
+                        // Check if this is a category header
+                        if (firstCell && firstCell.includes('TRIM LEVELS FOR {')) {
+                            currentCategory = categories.find(function(cat) {
+                                return firstCell.includes(cat);
+                            });
+                            
+                            if (currentCategory) {
+                                trimLevelRowsByCategory[currentCategory] = {};
+                                
+                                // Map features to column indices
+                                var features = row.slice(1).filter(function(f) { return f && f.trim() !== ''; }).map(function(f) {
+                                    var cleaned = f.trim();
+                                    if (cleaned.startsWith('"') && cleaned.endsWith('"')) {
+                                        cleaned = cleaned.slice(1, -1);
+                                    }
+                                    cleaned = cleaned.replace(/""/g, '"');
+                                    return cleaned;
+                                });
+                                
+                                features.forEach(function(feature, index) {
+                                    featureToColumnMap[feature] = index + 1;
+                                    featureToCategoryMap[feature] = currentCategory;
+                                });
+                            }
+                        } else if (currentCategory && trimLevels.indexOf(firstCell) !== -1) {
+                            // This is a trim level row for the current category
+                            trimLevelRowsByCategory[currentCategory][firstCell] = row;
+                        }
+                    }
+                });
+                
+                // Now populate the feature-to-trim-levels mapping using Cadillac function
+                populateFeatureTrimLevelsMapCadillac('ESCALADE ESV', featureToColumnMap, featureToCategoryMap, trimLevelRowsByCategory, trimLevels);
+
+                // Create global mappings for trim walk functionality
+                window.escaladeESVTrimLevelMap = featureToTrimLevelsMap['ESCALADE ESV'];
+                window.escaladeESVFeatureToCategoryMap = featureToCategoryMap;
+
+                console.log('Building HTML for Escalade ESV features...');
+                
+                // Build trim level walk buttons
+                var trimLevelButtons = buildTrimLevelWalkButtons(trimLevels, 'escaladeesv');
+                
+                var html = trimLevelButtons + '<div class="feature-groups">';
+                var globalIndex = 0;
+                categories.forEach(function(category) {
+                    var catFeatures = featureGroups[category] || [];
+                    console.log('Building HTML for category: ' + category + ' with ' + catFeatures.length + ' features');
+                    
+                    // Sort features alphabetically within each category
+                    catFeatures.sort(function(a, b) {
+                        return a.toLowerCase().localeCompare(b.toLowerCase());
+                    });
+                    
+                    html += '<div class="feature-column"><h4>' + category + '</h4><div class="gfield_checkbox">';
+                    
+                    // Build collapsible groups and regular features
+                    var categoryHtml = buildCollapsibleFeatureGroups(catFeatures, category, 'escaladeesv', globalIndex, undefined);
+                    html += categoryHtml.html;
+                    globalIndex = categoryHtml.globalIndex;
+                    html += '</div></div>';
+                });
+                html += '</div>';
+
+                console.log('Generated HTML length:', html.length);
+                console.log('HTML preview (first 500 chars):', html.substring(0, 500));
+
+                // Replace the placeholder in the HTML block
+                var currentHtml = htmlBlock.html();
+                console.log('Current HTML content:', currentHtml);
+                console.log('🔍 Searching for placeholder: {escalade esv feature checkboxes}');
+                console.log('🔍 Searching for placeholder: {ESCALADE ESV FEATURE CHECKBOXES}');
+                
+                if (currentHtml.indexOf('{escalade esv feature checkboxes}') !== -1) {
+                    var newHtml = currentHtml.replace('{escalade esv feature checkboxes}', html);
+                    htmlBlock.html(newHtml);
+                    console.log('✅ Replaced {escalade esv feature checkboxes} with generated HTML');
+                } else if (currentHtml.indexOf('{ESCALADE ESV FEATURE CHECKBOXES}') !== -1) {
+                    var newHtml = currentHtml.replace('{ESCALADE ESV FEATURE CHECKBOXES}', html);
+                    htmlBlock.html(newHtml);
+                    console.log('✅ Replaced {ESCALADE ESV FEATURE CHECKBOXES} with generated HTML');
+                } else {
+                    console.warn('❌ No Escalade ESV placeholder found in HTML block!');
+                    console.warn('📝 SOLUTION: Add {escalade esv feature checkboxes} to your HTML block field (ID 154)');
+                    console.warn('Available placeholders in HTML:', currentHtml.match(/\{[^}]+\}/g) || 'None found');
+                    htmlBlock.html(html);
+                }
+
+                escaladeESVPopulated = true;
+                console.log('Escalade ESV features populated into 5 columns in field 154');
+
+                // Bind change events and add info icons
+                htmlBlock.find('input[type="checkbox"]').off('change.EscaladeESVFeatures').on('change.EscaladeESVFeatures', function() {
+                    console.log('Escalade ESV checkbox changed, updating trim levels');
+                    updateTrimLevels('Escalade ESV');
+                });
+
+                // Set up collapsible group functionality
+                setupCollapsibleGroups(htmlBlock, 'Escalade ESV');
+
+                // Info icons are already included in the initial HTML generation above
+                // No need to prepend additional icons to avoid duplicates
+
+                // BULLETPROOF: Use global bulletproof handler instead of model-specific logic
+                htmlBlock.find('.feature-info-icon').off('click.featureInfo').on('click.featureInfo', function(e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    var feature = $(this).data('feature');
+                    if (!feature) return;
+                    
+                    console.log('🚀 BULLETPROOF (Escalade ESV): Feature icon clicked:', feature);
+                    var description = getFeatureDescription(feature, 'Escalade ESV');
+                    showFeatureDescription(feature, description);
+                });
+            },
+            error: function(error) {
+                console.error('Papa Parse error for Escalade ESV population: ' + error);
+            }
+        });
+    }).catch(function(error) {
+        console.error('Fetch error for Escalade ESV population: ' + error.message);
+    });
+}
+
 var acadiaPopulated = false;
 
 function populateAcadiaFeatures() {
@@ -9388,6 +9654,191 @@ function processEscaladeTrimLevels(csvData, selectedFeatures, htmlBlock, trimLev
 	window.escaladeFeatureToCategoryMap = featureToCategoryMap;
 }
 
+function processEscaladeESVTrimLevels(csvData, selectedFeatures, htmlBlock, trimLevelsButtonBlock, model) {
+	console.log('Processing Escalade ESV trim levels for selected features:', selectedFeatures);
+	
+	var categories = ['EXTERIOR', 'INTERIOR', 'MECHANICAL', 'SAFETY', 'PACKAGES'];
+	var trimLevels = discoverTrimLevelsFromCSV(csvData, categories);
+	
+	// Custom ordering for Escalade ESV trim levels: LUXURY, PREMIUM LUXURY, SPORT, PREMIUM LUXURY PLATINUM, SPORT PLATINUM
+	console.log('Escalade ESV processing - trim levels discovered:', trimLevels);
+	var escaladeESVTrimOrder = ['LUXURY', 'PREMIUM LUXURY', 'SPORT', 'PREMIUM LUXURY PLATINUM', 'SPORT PLATINUM'];
+	var orderedTrimLevels = [];
+	
+	// Add trim levels in the specified order
+	escaladeESVTrimOrder.forEach(function(orderedTrim) {
+		if (trimLevels.indexOf(orderedTrim) !== -1) {
+			orderedTrimLevels.push(orderedTrim);
+		}
+	});
+	
+	// Add any remaining trim levels that weren't in our custom order
+	trimLevels.forEach(function(trim) {
+		if (orderedTrimLevels.indexOf(trim) === -1) {
+			orderedTrimLevels.push(trim);
+		}
+	});
+	
+	trimLevels = orderedTrimLevels;
+	console.log('Escalade ESV processing - trim levels reordered:', trimLevels);
+	var matchingTrimLevels = [];
+	var featureToColumnMap = {};
+	var featureToCategoryMap = {};
+	var trimLevelRowsByCategory = {};
+	var currentCategory = null;
+	
+	// Parse the CSV data to map features to columns and find trim level rows
+	csvData.forEach(function(row, rowIndex) {
+		if (row && row.length > 0) {
+			var firstCell = row[0];
+			
+			// Check if this is a category header
+			if (firstCell && firstCell.includes('TRIM LEVELS FOR {')) {
+				currentCategory = categories.find(function(cat) {
+					return firstCell.includes(cat);
+				});
+				
+				if (currentCategory) {
+					trimLevelRowsByCategory[currentCategory] = {};
+					
+					// Map features to column indices
+					var features = row.slice(1).filter(function(f) { return f && f.trim() !== ''; }).map(function(f) {
+						var cleaned = f.trim();
+						if (cleaned.startsWith('"') && cleaned.endsWith('"')) {
+							cleaned = cleaned.slice(1, -1);
+						}
+						cleaned = cleaned.replace(/""/g, '"');
+						return cleaned;
+					});
+					
+					features.forEach(function(feature, index) {
+						featureToColumnMap[feature] = index + 1;
+						featureToCategoryMap[feature] = currentCategory;
+					});
+				}
+			} else if (currentCategory && trimLevels.includes(firstCell)) {
+				// This is a trim level row
+				trimLevelRowsByCategory[currentCategory][firstCell] = row;
+			}
+		}
+	});
+	
+	// For each trim level, check if it has all the selected features
+	trimLevels.forEach(function(trimLevel) {
+		var hasAllFeatures = true;
+		console.log('🔍 ESCALADE ESV TRIM LEVEL CHECK: ' + trimLevel);
+		
+		selectedFeatures.forEach(function(selectedFeature) {
+			var foundInTrimLevel = false;
+			console.log('  🔎 Checking feature: ' + selectedFeature);
+			
+			// Get the correct category for this feature
+			var featureCategory = featureToCategoryMap[selectedFeature];
+			console.log('  📂 Feature belongs to category: ' + featureCategory);
+			
+			if (featureCategory && trimLevelRowsByCategory[featureCategory] && trimLevelRowsByCategory[featureCategory][trimLevel]) {
+				var trimRow = trimLevelRowsByCategory[featureCategory][trimLevel];
+				var featureColumn = featureToColumnMap[selectedFeature];
+				
+				if (featureColumn && trimRow[featureColumn]) {
+					var featureValue = trimRow[featureColumn].toUpperCase();
+					console.log('    📋 Category: ' + featureCategory + ', Column: ' + featureColumn + ', Value: ' + featureValue);
+					
+					if (featureValue === 'YES') {
+						foundInTrimLevel = true;
+						console.log('    ✅ FOUND YES for ' + selectedFeature + ' in ' + trimLevel + ' (' + featureCategory + ')');
+					} else {
+						console.log('    ❌ NO for ' + selectedFeature + ' in ' + trimLevel + ' (' + featureCategory + ')');
+					}
+				} else {
+					console.log('    ⚠️ Feature not found in category: ' + featureCategory + ' (column: ' + featureColumn + ')');
+				}
+			} else {
+				console.log('    ❌ Category not found or no trim level data: ' + featureCategory);
+			}
+			
+			if (!foundInTrimLevel) {
+				hasAllFeatures = false;
+				console.log('  ❌ Feature ' + selectedFeature + ' NOT FOUND in ' + trimLevel);
+			} else {
+				console.log('  ✅ Feature ' + selectedFeature + ' FOUND in ' + trimLevel);
+			}
+		});
+		
+		if (hasAllFeatures) {
+			matchingTrimLevels.push(trimLevel);
+			console.log('✅ TRIM LEVEL MATCH: ' + trimLevel + ' has ALL features');
+		} else {
+			console.log('❌ TRIM LEVEL MISMATCH: ' + trimLevel + ' missing some features');
+		}
+	});
+	
+	console.log('Final matching Escalade ESV trim levels:', matchingTrimLevels);
+	trimLevelsData['ESCALADE ESV'] = matchingTrimLevels;
+	
+	// Update trim levels button with debouncing to prevent multiple calls
+	if (trimLevelsButtonBlock && trimLevelsButtonBlock.length) {
+		var buttonText = matchingTrimLevels.length > 0 ? 
+			'View Available Trim Levels (' + matchingTrimLevels.length + ')' :
+			'No Matching Trim Levels';
+		
+		// Clear any existing timeout to prevent multiple rapid updates
+		if (window.escaladeESVTrimButtonTimeout) {
+			clearTimeout(window.escaladeESVTrimButtonTimeout);
+		}
+		
+		window.escaladeESVTrimButtonTimeout = setTimeout(function() {
+			trimLevelsButtonBlock.html('<button type="button" id="viewTrimLevelsButton" class="button">' + buttonText + '</button>');
+			
+			// Remove ALL existing event handlers, not just namespaced ones
+			$('#viewTrimLevelsButton').off('click').on('click.trimLevels', function(e) {
+				e.preventDefault();
+				e.stopImmediatePropagation();
+				
+				// Prevent multiple rapid clicks
+				if (window.escaladeESVTrimPopupOpening) {
+					console.log('🚫 Escalade ESV trim popup already opening, ignoring click');
+					return;
+				}
+				
+				window.escaladeESVTrimPopupOpening = true;
+				
+				if (matchingTrimLevels.length > 0) {
+					var config = modelConfigs[model];
+					var correctModelFilter = config ? config.modelFilter : 'Escalade ESV';
+					console.log('🔵 Opening Escalade ESV trim popup for:', correctModelFilter);
+					showTrimLevelsPopup(model, matchingTrimLevels, correctModelFilter);
+				} else {
+					alert('No matching trim levels found for the selected features.');
+				}
+				
+				// Reset the flag after a delay
+				setTimeout(function() {
+					window.escaladeESVTrimPopupOpening = false;
+				}, 1000);
+			});
+		}, 100); // Small delay to prevent rapid multiple calls
+	}
+	
+	// Update field 69 with trim levels
+	if (htmlBlock && htmlBlock.length) {
+		var trimLevelsText = matchingTrimLevels.length > 0 ? matchingTrimLevels.join(', ') : 'No matching trim levels found';
+		var message = 'Wonderful, it sounds like the ' + trimLevelsText + ' would be the best fit, which has all of these features and it is available! One moment while I plug this car in.';
+		
+		htmlBlock.find('p').text(message);
+		console.log('✅ HTML block (ID: 69) updated for Escalade ESV with:', message);
+	} else {
+		console.warn('❌ HTML block (ID: 69) not found for Escalade ESV');
+	}
+	
+	// Populate feature-to-trim-levels mapping for display
+	populateFeatureTrimLevelsMapCadillac('ESCALADE ESV', featureToColumnMap, featureToCategoryMap, trimLevelRowsByCategory, trimLevels);
+	
+	// Create global mappings for trim walk functionality
+	window.escaladeESVTrimLevelMap = featureToTrimLevelsMap['ESCALADE ESV'];
+	window.escaladeESVFeatureToCategoryMap = featureToCategoryMap;
+}
+
 	function updateTrimLevels(model) {
     var config = modelConfigs[model];
     if (!config) {
@@ -10224,6 +10675,23 @@ function processEscaladeTrimLevels(csvData, selectedFeatures, htmlBlock, trimLev
                 hasFeatureMap: !!window.escaladeFeatureMap,
                 featureMapKeys: window.escaladeFeatureMap ? Object.keys(window.escaladeFeatureMap).slice(0, 5) : []
             });
+        } else if (model === 'ESCALADE ESV' || model === 'Escalade ESV') {
+            // For ESCALADE ESV, get feature from the global mapping using the checkbox value
+            var checkboxValue = $input.attr('value') || '';
+            feature = window.escaladeESVFeatureMap && window.escaladeESVFeatureMap[checkboxValue] ? window.escaladeESVFeatureMap[checkboxValue] : checkboxValue;
+            // If no mapping found, use the checkbox value directly as fallback
+            
+            console.log('ESCALADE ESV checkbox debug:', {
+                id: $input.attr('id'),
+                checkboxValue: checkboxValue,
+                mappedFeature: feature,
+                featureLength: feature.length,
+                name: $input.attr('name'),
+                checked: $input.is(':checked'),
+                labelText: $input.next('label').text().substring(0, 100),
+                hasFeatureMap: !!window.escaladeESVFeatureMap,
+                featureMapKeys: window.escaladeESVFeatureMap ? Object.keys(window.escaladeESVFeatureMap).slice(0, 5) : []
+            });
         } else {
             // For other models, use the existing logic
             var $div = $input.closest('.gfield_checkbox > div, .gfield-choice-wrapper');
@@ -10485,6 +10953,24 @@ function processEscaladeTrimLevels(csvData, selectedFeatures, htmlBlock, trimLev
                     console.log(model + ' CSV parsed, rows: ' + results.data.length);
                     console.log('First 10 rows of parsed data:', results.data.slice(0, 10));
                     processEscaladeTrimLevels(results.data, selectedFeatures, htmlBlock, trimLevelsButtonBlock, model);
+                }
+            });
+            return;
+        }
+        
+        // Special handling for ESCALADE ESV model
+        if (model === 'ESCALADE ESV' || model === 'Escalade ESV') {
+            // Log the full CSV content to debug data issues
+            console.log('=== FULL ESCALADE ESV CSV CONTENT ===');
+            console.log(csvText);
+            console.log('=== END ESCALADE ESV CSV CONTENT ===');
+            
+            Papa.parse(csvText, {
+                skipEmptyLines: true,
+                complete: function(results) {
+                    console.log(model + ' CSV parsed, rows: ' + results.data.length);
+                    console.log('First 10 rows of parsed data:', results.data.slice(0, 10));
+                    processEscaladeESVTrimLevels(results.data, selectedFeatures, htmlBlock, trimLevelsButtonBlock, model);
                 }
             });
             return;
@@ -12843,6 +13329,7 @@ function initFormBindings() {
                             window.trimPopupClosing = false;
                             window.trimPopupCreating = false;
                             window.escaladeTrimPopupOpening = false;
+                            window.escaladeESVTrimPopupOpening = false;
                             console.log('✅ Trim popup overlay close processing complete');
                         }, 500);
                     }
@@ -12878,6 +13365,7 @@ function initFormBindings() {
                         window.trimPopupClosing = false;
                         window.trimPopupCreating = false;
                         window.escaladeTrimPopupOpening = false;
+                        window.escaladeESVTrimPopupOpening = false;
                         console.log('✅ Trim popup close processing complete');
                     }, 500); // Increased timeout to ensure all events are processed
                     
@@ -14711,6 +15199,7 @@ function resetAllGlobalFlags() {
     window.trimPopupCreating = false;
     window.trimPopupClosing = false;
     window.escaladeTrimPopupOpening = false;
+    window.escaladeESVTrimPopupOpening = false;
     
     // Reset any existing popups
     $('#trimLevelsPopup, #trimLevelsOverlay, #vehiclePopup, #overlay, #notePopup, #noteOverlay, #featurePopup, #featureOverlay').remove();
@@ -14729,6 +15218,7 @@ function emergencyCleanupPopupFlags() {
     window.trimPopupCreating = false;
     window.trimPopupClosing = false;
     window.escaladeTrimPopupOpening = false;
+    window.escaladeESVTrimPopupOpening = false;
     window.isProcessingClick = false;
     
     // Force remove all popups
@@ -14739,13 +15229,14 @@ function emergencyCleanupPopupFlags() {
 
 // Safety mechanism: Reset stuck flags after 10 seconds if they're still set
 setInterval(function() {
-    var hasStuckFlags = window.trimPopupCreating || window.trimPopupClosing || window.escaladeTrimPopupOpening;
+    var hasStuckFlags = window.trimPopupCreating || window.trimPopupClosing || window.escaladeTrimPopupOpening || window.escaladeESVTrimPopupOpening;
     
     if (hasStuckFlags) {
         console.log('⚠️ SAFETY CHECK: Detected stuck popup flags, performing cleanup...');
         console.log('  - trimPopupCreating:', window.trimPopupCreating);
         console.log('  - trimPopupClosing:', window.trimPopupClosing);
         console.log('  - escaladeTrimPopupOpening:', window.escaladeTrimPopupOpening);
+        console.log('  - escaladeESVTrimPopupOpening:', window.escaladeESVTrimPopupOpening);
         
         // Check if there are actually any visible popups
         var visiblePopups = $('#trimLevelsPopup, #vehiclePopup, #notePopup, #featurePopup').length;
@@ -14844,6 +15335,14 @@ $(document).on('change', 'input[type="radio"]', function() {
             console.log('✅ ESCALADE population completed from global listener');
         }).catch(function(error) {
             console.error('❌ ESCALADE population failed from global listener:', error);
+        });
+    } else if ($(this).val() === 'Escalade ESV' && $(this).is(':checked')) {
+        console.log('🚨 ESCALADE ESV DETECTED IN GLOBAL LISTENER - FORCING POPULATE');
+        escaladeESVPopulated = false;
+        populateEscaladeESVFeatures().then(function() {
+            console.log('✅ ESCALADE ESV population completed from global listener');
+        }).catch(function(error) {
+            console.error('❌ ESCALADE ESV population failed from global listener:', error);
         });
     /*
     📋 STEP 10: GLOBAL RADIO BUTTON LISTENER - Add your model here

--- a/working code as of july 22nd.html
+++ b/working code as of july 22nd.html
@@ -696,6 +696,12 @@ jQuery(document).ready(function($) {
             margin-bottom: 4% !important;
             padding-bottom: 4px;
         }
+        
+        /* Cadillac XT4 checkbox spacing */
+        .gchoice[class*="gchoice_xt4_"] {
+            margin-bottom: 4% !important;
+            padding-bottom: 4px;
+        }
         /* Trim levels left alignment - force override any parent centering */
         .trim-levels-display {
             text-align: left !important;
@@ -930,6 +936,10 @@ jQuery(document).ready(function($) {
     // Cadillac Escalade ESV Model Field IDs
     var escaladeESVCheckboxFieldId = 154;
     var escaladeESVHtmlBlockFieldId = 154;
+    
+    // Cadillac XT4 Model Field IDs
+    var xt4CheckboxFieldId = 155;
+    var xt4HtmlBlockFieldId = 155;
 
     /*
     📋 STEP 1B: POPULATED FLAGS - Add your model's populated flag here
@@ -959,6 +969,7 @@ jQuery(document).ready(function($) {
     var ct5VSeriesPopulated = false;
     var escaladePopulated = false;
     var escaladeESVPopulated = false;
+    var xt4Populated = false;
     
     // Function to find best description match with fuzzy matching for typos
     function findBestDescriptionMatch(searchFeature, descriptionMap) {
@@ -1151,7 +1162,8 @@ jQuery(document).ready(function($) {
         'CT5': { fieldId: ct5CheckboxFieldId, csvUrl: 'https://hutchinsonautoteam.com/cadillacmodels/ct5.csv', modelFilter: 'CT5', isCadillac: true },
         'CT5 V-SERIES': { fieldId: ct5VSeriesCheckboxFieldId, csvUrl: 'https://hutchinsonautoteam.com/cadillacmodels/ct5v.csv', modelFilter: 'CT5', isCadillac: true },
         'Escalade': { fieldId: escaladeCheckboxFieldId, csvUrl: 'https://hutchinsonautoteam.com/cadillacmodels/escalade.csv', modelFilter: 'Escalade', isCadillac: true },
-        'Escalade ESV': { fieldId: escaladeESVCheckboxFieldId, csvUrl: 'https://hutchinsonautoteam.com/cadillacmodels/escaladeesv.csv', modelFilter: 'Escalade ESV', isCadillac: true }
+        'Escalade ESV': { fieldId: escaladeESVCheckboxFieldId, csvUrl: 'https://hutchinsonautoteam.com/cadillacmodels/escaladeesv.csv', modelFilter: 'Escalade ESV', isCadillac: true },
+        'XT4': { fieldId: xt4CheckboxFieldId, csvUrl: 'https://hutchinsonautoteam.com/cadillacmodels/xt4.csv', modelFilter: 'XT4', isCadillac: true }
     };
 
     // Email mappings
@@ -1495,6 +1507,9 @@ jQuery(document).ready(function($) {
     // Global variable for Cadillac Escalade ESV feature descriptions
     window.escaladeESVFeatureDescriptions = {};
     
+    // Global variable for Cadillac XT4 feature descriptions
+    window.xt4FeatureDescriptions = {};
+    
     // ============================================================================
     // FUTURE-PROOF DESCRIPTION SYSTEM
     // ============================================================================
@@ -1532,6 +1547,7 @@ jQuery(document).ready(function($) {
         'CT5 V-SERIES': 'https://hutchinsonautoteam.com/cadillacmodels/cadillacct5vdescriptions.csv',
         'Escalade': 'https://hutchinsonautoteam.com/cadillacmodels/cadillacescaladedescriptions.csv',
         'Escalade ESV': 'https://hutchinsonautoteam.com/cadillacmodels/cadillacescaladeesvdescriptions.csv',
+        'XT4': 'https://hutchinsonautoteam.com/cadillacmodels/cadillacxt4descriptions.csv',
         
         // Kia Models (using generic pattern - can be customized per model)
         'K4': 'https://hutchinsonautoteam.com/kiamodels/KIAMODELDESCRIPTIONS.CSV',
@@ -1656,6 +1672,9 @@ jQuery(document).ready(function($) {
                 break;
             case 'Escalade ESV':
                 window.escaladeESVFeatureDescriptions[featureUpper] = description;
+                break;
+            case 'XT4':
+                window.xt4FeatureDescriptions[featureUpper] = description;
                 break;
         }
     }
@@ -3003,6 +3022,11 @@ jQuery(document).ready(function($) {
                 modelName = 'Escalade ESV';
                 console.log('🔍 TRIM WALK: Escalade ESV descriptions found:', Object.keys(featureDescriptions || {}).length, 'descriptions');
                 break;
+            case 'xt4':
+                featureDescriptions = window.xt4FeatureDescriptions;
+                modelName = 'XT4';
+                console.log('🔍 TRIM WALK: XT4 descriptions found:', Object.keys(featureDescriptions || {}).length, 'descriptions');
+                break;
             default:
                 console.warn('Unknown model prefix for trim walk popup:', modelPrefix);
                 return;
@@ -3273,6 +3297,9 @@ jQuery(document).ready(function($) {
                 case 'escaladeesv':
                     alternativeNames.unshift('escaladeESVTrimLevelMap');
                     break;
+                case 'xt4':
+                    alternativeNames.unshift('xt4TrimLevelMap');
+                    break;
                 case 'ct4vseries':
                     alternativeNames.unshift('ct4VSeriesTrimLevelMap');
                     break;
@@ -3327,6 +3354,9 @@ jQuery(document).ready(function($) {
             switch(modelPrefix.toLowerCase()) {
                 case 'escaladeesv':
                     alternativeNames.push('escaladeESVFeatureToCategoryMap');
+                    break;
+                case 'xt4':
+                    alternativeNames.push('xt4FeatureToCategoryMap');
                     break;
                 case 'ct4vseries':
                     alternativeNames.push('ct4VSeriesFeatureToCategoryMap');
@@ -6567,6 +6597,235 @@ function populateEscaladeESVFeatures() {
         });
     }).catch(function(error) {
         console.error('Fetch error for Escalade ESV population: ' + error.message);
+    });
+}
+
+// Cadillac XT4 population function
+function populateXT4Features() {
+    console.log('=== populateXT4Features called ===');
+    
+    // FORCE CLEAR ANY CACHED DATA FOR XT4
+    console.log('🧹 CLEARING XT4 CACHED DATA...');
+    window.xt4FeatureMap = {};
+    window.xt4TrimLevelMap = {};
+    window.xt4FeatureToCategoryMap = {};
+    
+    console.log('Current xt4Populated flag:', xt4Populated);
+    console.log('Form ID:', formId);
+    console.log('xt4HtmlBlockFieldId:', xt4HtmlBlockFieldId);
+    
+    if (xt4Populated) {
+        console.log('XT4 features already populated, skipping');
+        return Promise.resolve();
+    }
+
+    var config = modelConfigs['XT4'];
+    if (!config) {
+        console.warn('XT4 configuration not found');
+        console.log('Available modelConfigs:', Object.keys(modelConfigs));
+        return Promise.reject(new Error('XT4 configuration not found'));
+    }
+    console.log('XT4 config found:', config);
+
+    // Try multiple selectors to find the HTML block field
+    console.log('Searching for HTML block field with multiple selectors...');
+    var htmlBlock = $('#field_' + formId + '_' + xt4HtmlBlockFieldId);
+    console.log('Selector 1 (#field_' + formId + '_' + xt4HtmlBlockFieldId + '):', htmlBlock.length);
+    
+    if (!htmlBlock.length) {
+        htmlBlock = $('#field_' + formId + '_155');
+        console.log('Selector 2 (#field_' + formId + '_155):', htmlBlock.length);
+    }
+    
+    if (!htmlBlock.length) {
+        htmlBlock = $('[id*="155"]').first();
+        console.log('Selector 3 ([id*="155"]):', htmlBlock.length);
+    }
+    
+    if (!htmlBlock.length) {
+        console.error('XT4 HTML block field not found! Tried selectors for field 155');
+        return Promise.reject(new Error('XT4 HTML block field not found'));
+    }
+
+    console.log('XT4 HTML block found:', htmlBlock.attr('id'));
+    console.log('XT4 CSV URL:', config.csvUrl);
+
+    return fetchCsvWithRetry(config.csvUrl, 'XT4 CSV', 3, 1000).then(function(csvText) {
+        console.log('XT4 CSV fetched successfully, length:', csvText.length, 'characters, first 100 chars:', csvText.substring(0, 100));
+
+        Papa.parse(csvText, {
+            header: false,
+            skipEmptyLines: true,
+            complete: function(results) {
+                console.log('XT4 CSV parsed, rows:', results.data.length);
+                console.log('First 10 rows of parsed data:', results.data.slice(0, 10));
+
+                var csvData = results.data;
+                var categories = ['EXTERIOR', 'INTERIOR', 'MECHANICAL', 'SAFETY', 'PACKAGES'];
+                var featureGroups = {};
+                var featureToColumnMap = {};
+                var featureToCategoryMap = {};
+                var trimLevelRowsByCategory = {};
+                var trimLevels = [];
+
+                // Initialize category objects
+                categories.forEach(function(category) {
+                    featureGroups[category] = [];
+                    trimLevelRowsByCategory[category] = {};
+                });
+
+                var currentCategory = null;
+                csvData.forEach(function(row, rowIndex) {
+                    console.log('Processing row', rowIndex, ':', row.slice(0, 5));
+                    if (row.length > 0 && row[0]) {
+                        var firstCell = row[0].trim();
+                        
+                        // Check if this is a category header
+                        var categoryMatch = firstCell.match(/TRIM LEVELS FOR \{(.+)\}/);
+                        if (categoryMatch) {
+                            currentCategory = categoryMatch[1];
+                            console.log('Found category:', currentCategory);
+                            
+                            if (categories.indexOf(currentCategory) !== -1) {
+                                // Extract features for this category (skip first column which is the header)
+                                var features = row.slice(1).filter(function(feature) {
+                                    return feature && feature.trim() && feature.trim() !== '';
+                                });
+                                
+                                console.log('🔍 XT4 CSV FEATURES in', currentCategory + ':', features.slice(0, 5));
+                                
+                                featureGroups[currentCategory] = features;
+                                
+                                // Map features to their column indices for trim level processing
+                                features.forEach(function(feature, index) {
+                                    var columnIndex = index + 1; // +1 because first column is category header
+                                    featureToColumnMap[feature] = columnIndex;
+                                    featureToCategoryMap[feature] = currentCategory;
+                                });
+                            }
+                        } else if (currentCategory && trimLevels.indexOf(firstCell) === -1 && firstCell !== '' && !firstCell.match(/TRIM LEVELS FOR/)) {
+                            // This might be a trim level
+                            if (row.some(function(cell) { return cell === 'YES' || cell === 'NO'; })) {
+                                trimLevels.push(firstCell);
+                                console.log('Found trim level:', firstCell);
+                                
+                                // Store the entire row for this trim level and category
+                                if (currentCategory) {
+                                    trimLevelRowsByCategory[currentCategory][firstCell] = row;
+                                }
+                            }
+                        } else if (currentCategory && trimLevels.indexOf(firstCell) !== -1) {
+                            // This is a trim level row for the current category
+                            trimLevelRowsByCategory[currentCategory][firstCell] = row;
+                        }
+                    }
+                });
+                
+                console.log('🔍 XT4 FINAL FEATURE MAP:', Object.keys(featureToColumnMap).slice(0, 10));
+                console.log('🔍 XT4 FINAL CATEGORY MAP:', featureToCategoryMap);
+                
+                // Now populate the feature-to-trim-levels mapping using Cadillac function
+                populateFeatureTrimLevelsMapCadillac('XT4', featureToColumnMap, featureToCategoryMap, trimLevelRowsByCategory, trimLevels);
+
+                // Create global mappings for trim walk functionality
+                window.xt4TrimLevelMap = featureToTrimLevelsMap['XT4'];
+                window.xt4FeatureToCategoryMap = featureToCategoryMap;
+
+                console.log('Building HTML for XT4 features...');
+                
+                // Build trim level walk buttons
+                var trimLevelButtons = buildTrimLevelWalkButtons(trimLevels, 'xt4');
+                
+                var html = trimLevelButtons + '<div class="feature-groups">';
+                var globalIndex = 0;
+                categories.forEach(function(category) {
+                    var catFeatures = featureGroups[category] || [];
+                    console.log('Building HTML for category: ' + category + ' with ' + catFeatures.length + ' features');
+                    
+                    // Sort features alphabetically within each category
+                    catFeatures.sort(function(a, b) {
+                        return a.toLowerCase().localeCompare(b.toLowerCase());
+                    });
+                    
+                    html += '<div class="feature-column"><h4>' + category + '</h4><div class="gfield_checkbox">';
+                    
+                    // Build collapsible groups and regular features
+                    var categoryHtml = buildCollapsibleFeatureGroups(catFeatures, category, 'xt4', globalIndex, undefined);
+                    html += categoryHtml.html;
+                    globalIndex = categoryHtml.globalIndex;
+                    html += '</div></div>';
+                });
+                html += '</div>';
+
+                console.log('Generated HTML length:', html.length);
+                console.log('HTML preview (first 500 chars):', html.substring(0, 500));
+
+                // Replace the placeholder in the HTML block
+                var currentHtml = htmlBlock.html();
+                console.log('Current HTML content:', currentHtml);
+                console.log('🔍 Searching for placeholder: {xt4 feature checkboxes}');
+                console.log('🔍 Searching for placeholder: {XT4 FEATURE CHECKBOXES}');
+                
+                if (currentHtml.indexOf('{xt4 feature checkboxes}') !== -1) {
+                    var newHtml = currentHtml.replace('{xt4 feature checkboxes}', html);
+                    htmlBlock.html(newHtml);
+                    console.log('✅ Replaced {xt4 feature checkboxes} with generated HTML');
+                } else if (currentHtml.indexOf('{XT4 FEATURE CHECKBOXES}') !== -1) {
+                    var newHtml = currentHtml.replace('{XT4 FEATURE CHECKBOXES}', html);
+                    htmlBlock.html(newHtml);
+                    console.log('✅ Replaced {XT4 FEATURE CHECKBOXES} with generated HTML');
+                } else {
+                    console.warn('❌ No XT4 placeholder found in HTML block!');
+                    console.warn('📝 SOLUTION: Add {xt4 feature checkboxes} to your HTML block field (ID 155)');
+                    console.warn('Available placeholders in HTML:', currentHtml.match(/\{[^}]+\}/g) || 'None found');
+                    htmlBlock.html(html);
+                }
+
+                // Create feature map for checkbox values to actual feature names
+                window.xt4FeatureMap = {};
+                htmlBlock.find('input[type="checkbox"]').each(function() {
+                    var checkboxValue = $(this).attr('value') || '';
+                    var actualFeature = $(this).next('label').text().trim(); // Get the actual feature name from the label
+                    if (checkboxValue && actualFeature) {
+                        window.xt4FeatureMap[checkboxValue] = actualFeature;
+                    }
+                });
+                console.log('Created xt4FeatureMap with', Object.keys(window.xt4FeatureMap).length, 'features');
+                console.log('Sample mapping:', Object.keys(window.xt4FeatureMap).slice(0, 3).map(function(key) {
+                    return key + ' -> ' + window.xt4FeatureMap[key];
+                }));
+
+                xt4Populated = true;
+                console.log('XT4 features populated into 5 columns in field 155');
+
+                // Bind change events and add info icons
+                htmlBlock.find('input[type="checkbox"]').off('change.XT4Features').on('change.XT4Features', function() {
+                    console.log('XT4 checkbox changed, updating trim levels');
+                    updateTrimLevels('XT4');
+                });
+
+                // Set up collapsible group functionality
+                setupCollapsibleGroups(htmlBlock, 'XT4');
+
+                // BULLETPROOF: Use global bulletproof handler instead of model-specific logic
+                htmlBlock.find('.feature-info-icon').off('click.featureInfo').on('click.featureInfo', function(e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    
+                    var feature = $(this).data('feature');
+                    if (!feature) return;
+                    
+                    console.log('🚀 BULLETPROOF (XT4): Feature icon clicked:', feature);
+                    var description = getFeatureDescription(feature, 'XT4');
+                    showFeatureDescription(feature, description);
+                });
+            },
+            error: function(error) {
+                console.error('Papa Parse error for XT4 population: ' + error);
+            }
+        });
+    }).catch(function(error) {
+        console.error('Fetch error for XT4 population: ' + error.message);
     });
 }
 
@@ -9946,6 +10205,212 @@ function processEscaladeESVTrimLevels(csvData, selectedFeatures, htmlBlock, trim
 	window.escaladeESVFeatureToCategoryMap = featureToCategoryMap;
 }
 
+function processXT4TrimLevels(csvData, selectedFeatures, htmlBlock, trimLevelsButtonBlock, model) {
+	console.log('Processing XT4 trim levels for selected features:', selectedFeatures);
+	console.log('🔍 XT4 DEBUG: csvData rows:', csvData.length);
+	console.log('🔍 XT4 DEBUG: First few CSV rows:', csvData.slice(0, 3));
+	console.log('🔍 XT4 DEBUG: Selected features detail:', selectedFeatures.map(function(f) {
+		return f + ' (length: ' + f.length + ')';
+	}));
+	
+	var categories = ['EXTERIOR', 'INTERIOR', 'MECHANICAL', 'SAFETY', 'PACKAGES'];
+	var trimLevels = discoverTrimLevelsFromCSV(csvData, categories);
+	
+	console.log('Discovered trim levels from CSV:', trimLevels);
+	console.log('XT4 processing - trim levels discovered:', trimLevels);
+	
+	// Reorder trim levels to standard Cadillac order
+	var standardOrder = ['PREMIUM LUXURY', 'SPORT'];
+	var orderedTrimLevels = [];
+	
+	// First add trim levels that match the standard order
+	standardOrder.forEach(function(standardTrim) {
+		if (trimLevels.indexOf(standardTrim) !== -1) {
+			orderedTrimLevels.push(standardTrim);
+		}
+	});
+	
+	// Then add any remaining trim levels not in standard order
+	trimLevels.forEach(function(trimLevel) {
+		if (orderedTrimLevels.indexOf(trimLevel) === -1) {
+			orderedTrimLevels.push(trimLevel);
+		}
+	});
+	
+	trimLevels = orderedTrimLevels;
+	console.log('XT4 processing - trim levels reordered:', trimLevels);
+	
+	var featureToColumnMap = {};
+	var featureToCategoryMap = {};
+	var trimLevelRowsByCategory = {};
+	var matchingTrimLevels = [];
+	
+	// Initialize category objects
+	categories.forEach(function(category) {
+		trimLevelRowsByCategory[category] = {};
+	});
+	
+	var currentCategory = null;
+	csvData.forEach(function(row) {
+		if (row.length > 0 && row[0]) {
+			var firstCell = row[0].trim();
+			
+			// Check if this is a category header
+			var categoryMatch = firstCell.match(/TRIM LEVELS FOR \{(.+)\}/);
+			if (categoryMatch) {
+				currentCategory = categoryMatch[1];
+				console.log('Found category:', currentCategory);
+				
+				if (categories.indexOf(currentCategory) !== -1) {
+					trimLevelRowsByCategory[currentCategory] = {};
+					
+					// Map features to column indices
+					var features = row.slice(1).filter(function(f) { return f && f.trim() !== ''; }).map(function(f) {
+						var cleaned = f.trim();
+						if (cleaned.startsWith('"') && cleaned.endsWith('"')) {
+							cleaned = cleaned.slice(1, -1);
+						}
+						cleaned = cleaned.replace(/""/g, '"');
+						return cleaned;
+					});
+					
+					console.log('🔍 XT4 CSV FEATURES in', currentCategory + ':', features.slice(0, 5));
+					
+					features.forEach(function(feature, index) {
+						featureToColumnMap[feature] = index + 1;
+						featureToCategoryMap[feature] = currentCategory;
+					});
+				}
+			} else if (currentCategory && trimLevels.includes(firstCell)) {
+				// This is a trim level row
+				trimLevelRowsByCategory[currentCategory][firstCell] = row;
+			}
+		}
+	});
+	
+	console.log('🔍 XT4 FINAL FEATURE MAP:', Object.keys(featureToColumnMap).slice(0, 10));
+	console.log('🔍 XT4 FINAL CATEGORY MAP:', featureToCategoryMap);
+	
+	// For each trim level, check if it has all the selected features
+	trimLevels.forEach(function(trimLevel) {
+		var hasAllFeatures = true;
+		console.log('🔍 XT4 TRIM LEVEL CHECK: ' + trimLevel);
+		
+		selectedFeatures.forEach(function(selectedFeature) {
+			var foundInTrimLevel = false;
+			console.log('  🔎 Checking feature: ' + selectedFeature);
+			
+			// Get the correct category for this feature
+			var featureCategory = featureToCategoryMap[selectedFeature];
+			console.log('  📂 Feature belongs to category: ' + featureCategory);
+			
+			if (featureCategory && trimLevelRowsByCategory[featureCategory] && trimLevelRowsByCategory[featureCategory][trimLevel]) {
+				var trimRow = trimLevelRowsByCategory[featureCategory][trimLevel];
+				var featureColumn = featureToColumnMap[selectedFeature];
+				
+				if (featureColumn && trimRow[featureColumn]) {
+					var featureValue = trimRow[featureColumn].toUpperCase();
+					console.log('    📋 Category: ' + featureCategory + ', Column: ' + featureColumn + ', Value: ' + featureValue);
+					
+					if (featureValue === 'YES') {
+						foundInTrimLevel = true;
+						console.log('    ✅ FOUND YES for ' + selectedFeature + ' in ' + trimLevel + ' (' + featureCategory + ')');
+					} else {
+						console.log('    ❌ NO for ' + selectedFeature + ' in ' + trimLevel + ' (' + featureCategory + ')');
+					}
+				} else {
+					console.log('    ❓ Feature column not found: ' + featureColumn);
+				}
+			} else {
+				console.log('    ❌ Category not found or no trim level data: ' + featureCategory);
+			}
+			
+			if (!foundInTrimLevel) {
+				hasAllFeatures = false;
+				console.log('  ❌ Feature ' + selectedFeature + ' NOT FOUND in ' + trimLevel);
+			} else {
+				console.log('  ✅ Feature ' + selectedFeature + ' FOUND in ' + trimLevel);
+			}
+		});
+		
+		if (hasAllFeatures) {
+			matchingTrimLevels.push(trimLevel);
+			console.log('✅ TRIM LEVEL MATCH: ' + trimLevel + ' has ALL features');
+		} else {
+			console.log('❌ TRIM LEVEL MISMATCH: ' + trimLevel + ' missing some features');
+		}
+	});
+	
+	console.log('Final matching XT4 trim levels:', matchingTrimLevels);
+	trimLevelsData['XT4'] = matchingTrimLevels;
+	
+	// Update trim levels button with debouncing to prevent multiple calls
+	if (trimLevelsButtonBlock && trimLevelsButtonBlock.length) {
+		var buttonText = matchingTrimLevels.length > 0 ? 
+			'View Available Trim Levels (' + matchingTrimLevels.length + ')' :
+			'No Matching Trim Levels';
+		
+		// Clear any existing timeout to prevent multiple rapid updates
+		if (window.xt4TrimButtonTimeout) {
+			clearTimeout(window.xt4TrimButtonTimeout);
+		}
+		
+		window.xt4TrimButtonTimeout = setTimeout(function() {
+			trimLevelsButtonBlock.html('<button type="button" id="viewTrimLevelsButton" class="button">' + buttonText + '</button>');
+			
+			// Remove ALL existing event handlers, not just namespaced ones
+			$('#viewTrimLevelsButton').off('click').on('click.trimLevels', function(e) {
+				e.preventDefault();
+				e.stopImmediatePropagation();
+				
+				// Prevent multiple rapid clicks
+				if (window.xt4TrimPopupOpening) {
+					console.log('🚫 XT4 trim popup already opening, ignoring click');
+					return;
+				}
+				
+				window.xt4TrimPopupOpening = true;
+				
+				if (matchingTrimLevels.length > 0) {
+					var config = modelConfigs[model];
+					var correctModelFilter = config ? config.modelFilter : 'XT4';
+					console.log('🔵 Opening XT4 trim popup for:', correctModelFilter);
+					
+					// Reset the flag before calling showTrimLevelsPopup to prevent conflicts
+					window.xt4TrimPopupOpening = false;
+					
+					showTrimLevelsPopup(model, matchingTrimLevels, correctModelFilter);
+				} else {
+					alert('No matching trim levels found for the selected features.');
+				}
+				
+				// Reset the flag after a delay
+				setTimeout(function() {
+					window.xt4TrimPopupOpening = false;
+				}, 1000);
+			});
+		}, 100); // Small delay to prevent rapid multiple calls
+	}
+	
+	// Update field 69 with trim levels
+	if (htmlBlock && htmlBlock.length) {
+		var trimLevelsText = matchingTrimLevels.length > 0 ? matchingTrimLevels.join(', ') : 'No matching trim levels found';
+		var message = 'Wonderful, it sounds like the ' + trimLevelsText + ' would be the best fit, which has all of these features and it is available! One moment while I plug this car in.';
+		
+		htmlBlock.find('p').text(message);
+		console.log('✅ HTML block (ID: 69) updated for XT4 with:', message);
+	} else {
+		console.warn('❌ HTML block (ID: 69) not found for XT4');
+	}
+	
+	// Populate feature-to-trim-levels mapping for display
+	populateFeatureTrimLevelsMapCadillac('XT4', featureToColumnMap, featureToCategoryMap, trimLevelRowsByCategory, trimLevels);
+	
+	// Create global mappings for trim walk functionality
+	window.xt4TrimLevelMap = featureToTrimLevelsMap['XT4'];
+	window.xt4FeatureToCategoryMap = featureToCategoryMap;
+}
+
 	function updateTrimLevels(model) {
     var config = modelConfigs[model];
     if (!config) {
@@ -10253,6 +10718,29 @@ function processEscaladeESVTrimLevels(csvData, selectedFeatures, htmlBlock, trim
         
         htmlBlock = $('#field_' + formId + '_' + htmlBlockFieldId);
         trimLevelsButtonBlock = $('#field_' + formId + '_' + trimLevelsButtonFieldId);
+    } else if (model === 'XT4') {
+        // For XT4, checkboxes are in field 155 (HTML block)
+        checkboxField = $('#field_' + formId + '_' + xt4HtmlBlockFieldId);
+        if (!checkboxField.length) {
+            checkboxField = $('#field_' + formId + '_155');
+        }
+        if (!checkboxField.length) {
+            checkboxField = $('[id*="155"]').filter(function() {
+                return $(this).attr('id').includes('field') || $(this).attr('id').includes('input');
+            });
+        }
+        
+        console.log('XT4 checkboxField debug:', {
+            xt4HtmlBlockFieldId: xt4HtmlBlockFieldId,
+            selector1: '#field_' + formId + '_' + xt4HtmlBlockFieldId,
+            selector2: '#field_' + formId + '_155',
+            found: checkboxField.length,
+            actualId: checkboxField.attr('id'),
+            hasCheckboxes: checkboxField.find('input[type="checkbox"]').length
+        });
+        
+        htmlBlock = $('#field_' + formId + '_' + htmlBlockFieldId);
+        trimLevelsButtonBlock = $('#field_' + formId + '_' + trimLevelsButtonFieldId);
     } else {
         // For other models, checkboxes are in their respective fields
         checkboxField = $('#field_' + formId + '_' + config.fieldId);
@@ -10264,7 +10752,7 @@ function processEscaladeESVTrimLevels(csvData, selectedFeatures, htmlBlock, trim
     var defaultButtonText = '<button id="viewTrimLevelsButton">View Trim Levels</button>';
     var noMatchText = 'No matching trim levels found. Please adjust your feature selections or contact support.';
 
-    console.log('Checking ' + model + ' checkbox field (ID: ' + (model === 'TERRAIN' ? terrainHtmlBlockFieldId : model === 'ACADIA' ? acadiaHtmlBlockFieldId : model === 'YUKON' ? yukonHtmlBlockFieldId : model === 'CANYON' ? canyonHtmlBlockFieldId : model === 'SIERRA 1500' ? sierra1500HtmlBlockFieldId : (model === 'SIERRA 2500' || model === 'SIERRA 2500HD') ? sierra2500HtmlBlockFieldId : (model === 'SIERRA 3500' || model === 'SIERRA 3500HD') ? sierra3500HtmlBlockFieldId : model === 'CT4' ? ct4HtmlBlockFieldId : model === 'CT4 V-SERIES' ? ct4VSeriesHtmlBlockFieldId : model === 'CT5' ? ct5HtmlBlockFieldId : model === 'CT5 V-SERIES' ? ct5VSeriesHtmlBlockFieldId : model === 'ESCALADE' ? escaladeHtmlBlockFieldId : (model === 'ESCALADE ESV' || model === 'Escalade ESV') ? escaladeESVHtmlBlockFieldId : config.fieldId) + '):', {
+    console.log('Checking ' + model + ' checkbox field (ID: ' + (model === 'TERRAIN' ? terrainHtmlBlockFieldId : model === 'ACADIA' ? acadiaHtmlBlockFieldId : model === 'YUKON' ? yukonHtmlBlockFieldId : model === 'CANYON' ? canyonHtmlBlockFieldId : model === 'SIERRA 1500' ? sierra1500HtmlBlockFieldId : (model === 'SIERRA 2500' || model === 'SIERRA 2500HD') ? sierra2500HtmlBlockFieldId : (model === 'SIERRA 3500' || model === 'SIERRA 3500HD') ? sierra3500HtmlBlockFieldId : model === 'CT4' ? ct4HtmlBlockFieldId : model === 'CT4 V-SERIES' ? ct4VSeriesHtmlBlockFieldId : model === 'CT5' ? ct5HtmlBlockFieldId : model === 'CT5 V-SERIES' ? ct5VSeriesHtmlBlockFieldId : model === 'ESCALADE' ? escaladeHtmlBlockFieldId : (model === 'ESCALADE ESV' || model === 'Escalade ESV') ? escaladeESVHtmlBlockFieldId : model === 'XT4' ? xt4HtmlBlockFieldId : config.fieldId) + '):', {
         fieldExists: checkboxField.length > 0,
         fieldVisible: checkboxField.is(':visible'),
         fieldClasses: checkboxField.attr('class'),
@@ -10550,7 +11038,7 @@ function processEscaladeESVTrimLevels(csvData, selectedFeatures, htmlBlock, trim
         showFeatureDescription(feature, description);
     });
 
-    if (!checkboxField.length || (model !== 'K5' && model !== 'TERRAIN' && model !== 'ACADIA' && model !== 'YUKON' && model !== 'CANYON' && model !== 'SIERRA 1500' && model !== 'SIERRA 2500' && model !== 'SIERRA 2500HD' && model !== 'SIERRA 3500' && model !== 'SIERRA 3500HD' && model !== 'CT4' && model !== 'CT4 V-SERIES' && model !== 'CT5' && model !== 'CT5 V-SERIES' && model !== 'ESCALADE' && model !== 'Escalade' && model !== 'ESCALADE ESV' && model !== 'Escalade ESV' && !checkboxField.is(':visible'))) {
+    if (!checkboxField.length || (model !== 'K5' && model !== 'TERRAIN' && model !== 'ACADIA' && model !== 'YUKON' && model !== 'CANYON' && model !== 'SIERRA 1500' && model !== 'SIERRA 2500' && model !== 'SIERRA 2500HD' && model !== 'SIERRA 3500' && model !== 'SIERRA 3500HD' && model !== 'CT4' && model !== 'CT4 V-SERIES' && model !== 'CT5' && model !== 'CT5 V-SERIES' && model !== 'ESCALADE' && model !== 'Escalade' && model !== 'ESCALADE ESV' && model !== 'Escalade ESV' && model !== 'XT4' && !checkboxField.is(':visible'))) {
         console.log(model + ' checkbox field not found or not visible, resetting HTML block');
         if (htmlBlock.length) {
             htmlBlock.find('p').text(defaultText);
@@ -10821,6 +11309,23 @@ function processEscaladeESVTrimLevels(csvData, selectedFeatures, htmlBlock, trim
                 labelText: $input.next('label').text().substring(0, 100),
                 hasFeatureMap: !!window.escaladeESVFeatureMap,
                 featureMapKeys: window.escaladeESVFeatureMap ? Object.keys(window.escaladeESVFeatureMap).slice(0, 5) : []
+            });
+        } else if (model === 'XT4') {
+            // For XT4, get feature from the global mapping using the checkbox value
+            var checkboxValue = $input.attr('value') || '';
+            feature = window.xt4FeatureMap && window.xt4FeatureMap[checkboxValue] ? window.xt4FeatureMap[checkboxValue] : checkboxValue;
+            // If no mapping found, use the checkbox value directly as fallback
+            
+            console.log('XT4 checkbox debug:', {
+                id: $input.attr('id'),
+                checkboxValue: checkboxValue,
+                mappedFeature: feature,
+                featureLength: feature.length,
+                name: $input.attr('name'),
+                checked: $input.is(':checked'),
+                labelText: $input.next('label').text().substring(0, 100),
+                hasFeatureMap: !!window.xt4FeatureMap,
+                featureMapKeys: window.xt4FeatureMap ? Object.keys(window.xt4FeatureMap).slice(0, 5) : []
             });
         } else {
             // For other models, use the existing logic
@@ -11101,6 +11606,24 @@ function processEscaladeESVTrimLevels(csvData, selectedFeatures, htmlBlock, trim
                     console.log(model + ' CSV parsed, rows: ' + results.data.length);
                     console.log('First 10 rows of parsed data:', results.data.slice(0, 10));
                     processEscaladeESVTrimLevels(results.data, selectedFeatures, htmlBlock, trimLevelsButtonBlock, model);
+                }
+            });
+            return;
+        }
+        
+        // Special handling for XT4 model
+        if (model === 'XT4') {
+            // Log the full CSV content to debug data issues
+            console.log('=== FULL XT4 CSV CONTENT ===');
+            console.log(csvText);
+            console.log('=== END XT4 CSV CONTENT ===');
+            
+            Papa.parse(csvText, {
+                skipEmptyLines: true,
+                complete: function(results) {
+                    console.log(model + ' CSV parsed, rows: ' + results.data.length);
+                    console.log('First 10 rows of parsed data:', results.data.slice(0, 10));
+                    processXT4TrimLevels(results.data, selectedFeatures, htmlBlock, trimLevelsButtonBlock, model);
                 }
             });
             return;
@@ -15338,6 +15861,7 @@ function resetAllGlobalFlags() {
     window.trimPopupClosing = false;
     window.escaladeTrimPopupOpening = false;
     window.escaladeESVTrimPopupOpening = false;
+    window.xt4TrimPopupOpening = false;
     
     // Reset any existing popups
     $('#trimLevelsPopup, #trimLevelsOverlay, #vehiclePopup, #overlay, #notePopup, #noteOverlay, #featurePopup, #featureOverlay').remove();
@@ -15357,6 +15881,7 @@ function emergencyCleanupPopupFlags() {
     window.trimPopupClosing = false;
     window.escaladeTrimPopupOpening = false;
     window.escaladeESVTrimPopupOpening = false;
+    window.xt4TrimPopupOpening = false;
     window.isProcessingClick = false;
     
     // Force remove all popups
@@ -15367,7 +15892,7 @@ function emergencyCleanupPopupFlags() {
 
 // Safety mechanism: Reset stuck flags after 10 seconds if they're still set
 setInterval(function() {
-    var hasStuckFlags = window.trimPopupCreating || window.trimPopupClosing || window.escaladeTrimPopupOpening || window.escaladeESVTrimPopupOpening;
+    var hasStuckFlags = window.trimPopupCreating || window.trimPopupClosing || window.escaladeTrimPopupOpening || window.escaladeESVTrimPopupOpening || window.xt4TrimPopupOpening;
     
     if (hasStuckFlags) {
         console.log('⚠️ SAFETY CHECK: Detected stuck popup flags, performing cleanup...');
@@ -15375,6 +15900,7 @@ setInterval(function() {
         console.log('  - trimPopupClosing:', window.trimPopupClosing);
         console.log('  - escaladeTrimPopupOpening:', window.escaladeTrimPopupOpening);
         console.log('  - escaladeESVTrimPopupOpening:', window.escaladeESVTrimPopupOpening);
+        console.log('  - xt4TrimPopupOpening:', window.xt4TrimPopupOpening);
         
         // Check if there are actually any visible popups
         var visiblePopups = $('#trimLevelsPopup, #vehiclePopup, #notePopup, #featurePopup').length;
@@ -15481,6 +16007,14 @@ $(document).on('change', 'input[type="radio"]', function() {
             console.log('✅ ESCALADE ESV population completed from global listener');
         }).catch(function(error) {
             console.error('❌ ESCALADE ESV population failed from global listener:', error);
+        });
+    } else if ($(this).val() === 'XT4' && $(this).is(':checked')) {
+        console.log('🚨 XT4 DETECTED IN GLOBAL LISTENER - FORCING POPULATE');
+        xt4Populated = false;
+        populateXT4Features().then(function() {
+            console.log('✅ XT4 population completed from global listener');
+        }).catch(function(error) {
+            console.error('❌ XT4 population failed from global listener:', error);
         });
     /*
     📋 STEP 10: GLOBAL RADIO BUTTON LISTENER - Add your model here

--- a/working code as of july 22nd.html
+++ b/working code as of july 22nd.html
@@ -6466,11 +6466,15 @@ function populateEscaladeESVFeatures() {
                 window.escaladeESVFeatureMap = {};
                 htmlBlock.find('input[type="checkbox"]').each(function() {
                     var checkboxValue = $(this).attr('value') || '';
-                    if (checkboxValue) {
-                        window.escaladeESVFeatureMap[checkboxValue] = checkboxValue;
+                    var actualFeature = $(this).next('label').text().trim(); // Get the actual feature name from the label
+                    if (checkboxValue && actualFeature) {
+                        window.escaladeESVFeatureMap[checkboxValue] = actualFeature;
                     }
                 });
                 console.log('Created escaladeESVFeatureMap with', Object.keys(window.escaladeESVFeatureMap).length, 'features');
+                console.log('Sample mapping:', Object.keys(window.escaladeESVFeatureMap).slice(0, 3).map(function(key) {
+                    return key + ' -> ' + window.escaladeESVFeatureMap[key];
+                }));
 
                 escaladeESVPopulated = true;
                 console.log('Escalade ESV features populated into 5 columns in field 154');
@@ -9685,6 +9689,11 @@ function processEscaladeTrimLevels(csvData, selectedFeatures, htmlBlock, trimLev
 
 function processEscaladeESVTrimLevels(csvData, selectedFeatures, htmlBlock, trimLevelsButtonBlock, model) {
 	console.log('Processing Escalade ESV trim levels for selected features:', selectedFeatures);
+	console.log('🔍 ESCALADE ESV DEBUG: csvData rows:', csvData.length);
+	console.log('🔍 ESCALADE ESV DEBUG: First few CSV rows:', csvData.slice(0, 3));
+	console.log('🔍 ESCALADE ESV DEBUG: Selected features detail:', selectedFeatures.map(function(f) {
+		return f + ' (length: ' + f.length + ')';
+	}));
 	
 	var categories = ['EXTERIOR', 'INTERIOR', 'MECHANICAL', 'SAFETY', 'PACKAGES'];
 	var trimLevels = discoverTrimLevelsFromCSV(csvData, categories);
@@ -9744,6 +9753,8 @@ function processEscaladeESVTrimLevels(csvData, selectedFeatures, htmlBlock, trim
 						featureToColumnMap[feature] = index + 1;
 						featureToCategoryMap[feature] = currentCategory;
 					});
+					
+					console.log('🔍 ESCALADE ESV CSV FEATURES in', currentCategory + ':', features.slice(0, 5));
 				}
 			} else if (currentCategory && trimLevels.includes(firstCell)) {
 				// This is a trim level row
@@ -9751,6 +9762,9 @@ function processEscaladeESVTrimLevels(csvData, selectedFeatures, htmlBlock, trim
 			}
 		}
 	});
+	
+	console.log('🔍 ESCALADE ESV FINAL FEATURE MAP:', Object.keys(featureToColumnMap).slice(0, 10));
+	console.log('🔍 ESCALADE ESV FINAL CATEGORY MAP:', featureToCategoryMap);
 	
 	// For each trim level, check if it has all the selected features
 	trimLevels.forEach(function(trimLevel) {

--- a/working code as of july 22nd.html
+++ b/working code as of july 22nd.html
@@ -2345,6 +2345,72 @@ jQuery(document).ready(function($) {
         });
     }
 
+    // Load Cadillac XT4 feature descriptions
+    function loadXT4FeatureDescriptions() {
+        var xt4DescriptionsUrl = 'https://hutchinsonautoteam.com/cadillacmodels/cadillacxt4descriptions.csv';
+        console.log('Loading Cadillac XT4 feature descriptions from:', xt4DescriptionsUrl);
+        
+        fetch(xt4DescriptionsUrl)
+        .then(function(response) {
+            if (!response.ok) {
+                throw new Error('Network response was not ok: ' + response.status);
+            }
+            return response.text();
+        })
+        .then(function(csvText) {
+            console.log('Raw XT4 descriptions CSV:', csvText);
+            console.log('Raw XT4 descriptions CSV length:', csvText.length);
+            console.log('Raw XT4 descriptions CSV preview (first 500 chars):', csvText.substring(0, 500));
+            
+            window.xt4FeatureDescriptions = {};
+            
+            // Parse CSV text line by line
+            var lines = csvText.split('\n');
+            console.log('XT4 descriptions total lines:', lines.length);
+            
+            lines.forEach(function(line, index) {
+                if (line.trim() && line.includes('{') && line.includes('}') && line.includes(':')) {
+                    console.log('Processing XT4 description line', index, ':', line.substring(0, 100) + '...');
+                    
+                    // Find the closing brace
+                    var startBrace = line.indexOf('{');
+                    var endBrace = line.lastIndexOf('}');
+                    if (startBrace !== -1 && endBrace !== -1 && endBrace > startBrace) {
+                        var content = line.substring(startBrace + 1, endBrace);
+                        var colonIndex = content.indexOf(':');
+                        if (colonIndex !== -1) {
+                            var feature = content.substring(0, colonIndex).trim();
+                            var description = content.substring(colonIndex + 1).trim();
+                            
+                            if (feature && description) {
+                                var featureUpper = feature.toUpperCase();
+                                window.xt4FeatureDescriptions[featureUpper] = description;
+                                console.log('Added XT4 description:', featureUpper, '=', description.substring(0, 100) + '...');
+                            }
+                        }
+                    }
+                }
+            });
+            
+            console.log('Parsed XT4 feature descriptions:', window.xt4FeatureDescriptions);
+            console.log('Total XT4 descriptions loaded:', Object.keys(window.xt4FeatureDescriptions).length);
+            
+            if (Object.keys(window.xt4FeatureDescriptions).length === 0) {
+                console.warn('WARNING: No XT4 feature descriptions loaded!');
+                console.warn('Sample lines from XT4 descriptions CSV:');
+                lines.slice(0, 5).forEach(function(line, index) {
+                    console.warn('Line', index, ':', line);
+                });
+            } else {
+                console.log('SUCCESS: Cadillac XT4 descriptions loaded successfully at:', new Date().toISOString());
+                console.log('First few XT4 descriptions:', Object.keys(window.xt4FeatureDescriptions).slice(0, 5));
+            }
+        }).catch(function(error) {
+            console.error('Fetch error for Cadillac XT4 Feature Descriptions:', error.message);
+            window.xt4FeatureDescriptions = {};
+        });
+    }
+
     // Removed backup system - using only real descriptions from CSV files
 
     // Exact matching function only - no fuzzy matching
@@ -6650,21 +6716,7 @@ function populateXT4Features() {
     console.log('XT4 HTML block found:', htmlBlock.attr('id'));
     console.log('XT4 CSV URL:', config.csvUrl);
 
-    // Load XT4 descriptions first
-    var descriptionsUrl = descriptionUrlMap['XT4'];
-    console.log('XT4 descriptions URL:', descriptionsUrl);
-    
-    return loadModelDescriptions('XT4', descriptionsUrl).then(function() {
-        console.log('✅ XT4 descriptions loaded successfully');
-        console.log('XT4 descriptions count:', Object.keys(window.xt4FeatureDescriptions || {}).length);
-        console.log('XT4 descriptions sample:', Object.keys(window.xt4FeatureDescriptions || {}).slice(0, 5));
-        
-        return fetchCsvWithRetry(config.csvUrl, 'XT4 CSV', 3, 1000);
-    }).catch(function(error) {
-        console.error('❌ Failed to load XT4 descriptions:', error);
-        console.log('🔄 Continuing without XT4 descriptions...');
-        return fetchCsvWithRetry(config.csvUrl, 'XT4 CSV', 3, 1000);
-    }).then(function(csvText) {
+    return fetchCsvWithRetry(config.csvUrl, 'XT4 CSV', 3, 1000).then(function(csvText) {
         console.log('XT4 CSV fetched successfully, length:', csvText.length, 'characters');
         console.log('XT4 CSV first 200 chars:', csvText.substring(0, 200));
         console.log('XT4 CSV first line:', csvText.split('\n')[0]);
@@ -15602,6 +15654,7 @@ loadCT4VSeriesFeatureDescriptions();
 loadCT5FeatureDescriptions();
 loadCT5VSeriesFeatureDescriptions();
 loadEscaladeFeatureDescriptions();
+loadXT4FeatureDescriptions();
 
 // Load Escalade ESV feature descriptions (wrapper for centralized system)
 function loadEscaladeESVFeatureDescriptions() {

--- a/working code as of july 22nd.html
+++ b/working code as of july 22nd.html
@@ -6675,17 +6675,21 @@ function populateXT4Features() {
                     trimLevelRowsByCategory[category] = {};
                 });
 
+                console.log('🔍 XT4 CSV PARSING: Total rows:', csvData.length);
+                console.log('🔍 XT4 CSV PARSING: First few rows:', csvData.slice(0, 5));
+                
                 var currentCategory = null;
+                
                 csvData.forEach(function(row, rowIndex) {
-                    console.log('Processing row', rowIndex, ':', row.slice(0, 5));
                     if (row.length > 0 && row[0]) {
                         var firstCell = row[0].trim();
+                        console.log('Processing XT4 row', rowIndex, '- First cell:', firstCell, '- Row length:', row.length);
                         
-                        // Check if this is a category header
+                        // Check if this is a category header row: "TRIM LEVELS FOR {EXTERIOR}"
                         var categoryMatch = firstCell.match(/TRIM LEVELS FOR \{(.+)\}/);
                         if (categoryMatch) {
                             currentCategory = categoryMatch[1];
-                            console.log('Found category:', currentCategory);
+                            console.log('🎯 Found XT4 category:', currentCategory);
                             
                             if (categories.indexOf(currentCategory) !== -1) {
                                 // Extract features for this category (skip first column which is the header)
@@ -6693,33 +6697,45 @@ function populateXT4Features() {
                                     return feature && feature.trim() && feature.trim() !== '';
                                 });
                                 
-                                console.log('🔍 XT4 CSV FEATURES in', currentCategory + ':', features.slice(0, 5));
+                                console.log('🔍 XT4 CSV FEATURES in', currentCategory + ':', features.length, 'features');
+                                console.log('🔍 First 5 features:', features.slice(0, 5));
                                 
                                 featureGroups[currentCategory] = features;
                                 
                                 // Map features to their column indices for trim level processing
                                 features.forEach(function(feature, index) {
-                                    var columnIndex = index + 1; // +1 because first column is category header
-                                    featureToColumnMap[feature] = columnIndex;
+                                    var colIndex = index + 1; // +1 because first column is category header
+                                    featureToColumnMap[feature] = colIndex;
                                     featureToCategoryMap[feature] = currentCategory;
                                 });
                             }
-                        } else if (currentCategory && trimLevels.indexOf(firstCell) === -1 && firstCell !== '' && !firstCell.match(/TRIM LEVELS FOR/)) {
-                            // This might be a trim level
-                            if (row.some(function(cell) { return cell === 'YES' || cell === 'NO'; })) {
+                        } else if (currentCategory && (firstCell === 'PREMIUM LUXURY' || firstCell === 'SPORT')) {
+                            // This is a trim level row
+                            if (trimLevels.indexOf(firstCell) === -1) {
                                 trimLevels.push(firstCell);
-                                console.log('Found trim level:', firstCell);
-                                
-                                // Store the entire row for this trim level and category
-                                if (currentCategory) {
-                                    trimLevelRowsByCategory[currentCategory][firstCell] = row;
-                                }
+                                console.log('🎯 Found XT4 trim level:', firstCell);
                             }
-                        } else if (currentCategory && trimLevels.indexOf(firstCell) !== -1) {
-                            // This is a trim level row for the current category
+                            
+                            // Store the entire row for this trim level and category
+                            if (!trimLevelRowsByCategory[currentCategory]) {
+                                trimLevelRowsByCategory[currentCategory] = {};
+                            }
                             trimLevelRowsByCategory[currentCategory][firstCell] = row;
+                            console.log('📊 Stored trim data for', firstCell, 'in category', currentCategory);
+                        } else if (firstCell === '' || firstCell.match(/^,+$/)) {
+                            // Skip empty rows or rows with just commas
+                            console.log('⏭️ Skipping empty row', rowIndex);
+                        } else {
+                            console.log('❓ Unrecognized row format:', firstCell);
                         }
                     }
+                });
+                
+                console.log('🏁 XT4 CSV PARSING COMPLETE:');
+                console.log('📋 Categories found:', Object.keys(featureGroups));
+                console.log('🎯 Trim levels found:', trimLevels);
+                categories.forEach(function(cat) {
+                    console.log('📦', cat, ':', featureGroups[cat] ? featureGroups[cat].length : 0, 'features');
                 });
                 
                 console.log('🔍 XT4 FINAL FEATURE MAP:', Object.keys(featureToColumnMap).slice(0, 10));

--- a/working code as of july 22nd.html
+++ b/working code as of july 22nd.html
@@ -2990,6 +2990,10 @@ jQuery(document).ready(function($) {
                 featureDescriptions = window.escaladeFeatureDescriptions;
                 modelName = 'Escalade';
                 break;
+            case 'escaladeesv':
+                featureDescriptions = window.escaladeESVFeatureDescriptions;
+                modelName = 'Escalade ESV';
+                break;
             default:
                 console.warn('Unknown model prefix for trim walk popup:', modelPrefix);
                 return;
@@ -3709,6 +3713,8 @@ jQuery(document).ready(function($) {
                 return 'CT5 V-SERIES';
             case 'ESCALADE':
                 return 'Escalade';
+            case 'ESCALADEESV':
+                return 'Escalade ESV';
             default:
                  return modelName;
          }
@@ -3810,7 +3816,7 @@ jQuery(document).ready(function($) {
             */
             
             // Current Cadillac models
-            'ct4', 'ct4vseries', 'ct4v', 'ct5', 'ct5vseries', 'ct5v', 'xt4', 'xt5', 'xt6', 'escalade',
+            'ct4', 'ct4vseries', 'ct4v', 'ct5', 'ct5vseries', 'ct5v', 'xt4', 'xt5', 'xt6', 'escalade', 'escaladeesv',
              
              // Potential future GMC models
              'silverado', 'tahoe', 'suburban', 'equinox', 'traverse', 'blazer', 'trax',
@@ -6387,10 +6393,10 @@ function populateEscaladeESVFeatures() {
                 });
                 
                 // Now populate the feature-to-trim-levels mapping using Cadillac function
-                populateFeatureTrimLevelsMapCadillac('ESCALADE ESV', featureToColumnMap, featureToCategoryMap, trimLevelRowsByCategory, trimLevels);
+                populateFeatureTrimLevelsMapCadillac('ESCALADEESV', featureToColumnMap, featureToCategoryMap, trimLevelRowsByCategory, trimLevels);
 
                 // Create global mappings for trim walk functionality
-                window.escaladeESVTrimLevelMap = featureToTrimLevelsMap['ESCALADE ESV'];
+                window.escaladeESVTrimLevelMap = featureToTrimLevelsMap['ESCALADEESV'];
                 window.escaladeESVFeatureToCategoryMap = featureToCategoryMap;
 
                 console.log('Building HTML for Escalade ESV features...');
@@ -6442,6 +6448,16 @@ function populateEscaladeESVFeatures() {
                     console.warn('Available placeholders in HTML:', currentHtml.match(/\{[^}]+\}/g) || 'None found');
                     htmlBlock.html(html);
                 }
+
+                // Create feature map for updateTrimLevels function
+                window.escaladeESVFeatureMap = {};
+                htmlBlock.find('input[type="checkbox"]').each(function() {
+                    var checkboxValue = $(this).attr('value') || '';
+                    if (checkboxValue) {
+                        window.escaladeESVFeatureMap[checkboxValue] = checkboxValue;
+                    }
+                });
+                console.log('Created escaladeESVFeatureMap with', Object.keys(window.escaladeESVFeatureMap).length, 'features');
 
                 escaladeESVPopulated = true;
                 console.log('Escalade ESV features populated into 5 columns in field 154');
@@ -14906,6 +14922,14 @@ loadCT4VSeriesFeatureDescriptions();
 loadCT5FeatureDescriptions();
 loadCT5VSeriesFeatureDescriptions();
 loadEscaladeFeatureDescriptions();
+
+// Load Escalade ESV feature descriptions (wrapper for centralized system)
+function loadEscaladeESVFeatureDescriptions() {
+    console.log('Loading Escalade ESV feature descriptions via centralized system...');
+    // The centralized system already loads this via loadAllModelDescriptions()
+    // This function exists for backward compatibility
+}
+loadEscaladeESVFeatureDescriptions();
 initFormBindings();
 updateSelectedName();
 
@@ -15424,6 +15448,7 @@ function getFeatureDescription(feature, model) {
     
     // Fallback: Try all description sources with direct lookup only
     var allDescriptionSources = [
+        { name: 'Escalade ESV', data: typeof window.escaladeESVFeatureDescriptions !== 'undefined' ? window.escaladeESVFeatureDescriptions : {} },
         { name: 'Escalade', data: typeof window.escaladeFeatureDescriptions !== 'undefined' ? window.escaladeFeatureDescriptions : {} },
         { name: 'CT5 V-Series', data: typeof window.ct5VSeriesFeatureDescriptions !== 'undefined' ? window.ct5VSeriesFeatureDescriptions : {} },
         { name: 'CT5', data: typeof window.ct5FeatureDescriptions !== 'undefined' ? window.ct5FeatureDescriptions : {} },
@@ -15538,6 +15563,9 @@ function getModelDescriptionMap(model) {
         case 'ESCALADE':
         case 'Escalade':
             return window.escaladeFeatureDescriptions;
+        case 'ESCALADE ESV':
+        case 'Escalade ESV':
+            return window.escaladeESVFeatureDescriptions;
         case 'CT4':
             return window.ct4FeatureDescriptions;
         case 'CT4 V-SERIES':

--- a/working code as of july 22nd.html
+++ b/working code as of july 22nd.html
@@ -6657,7 +6657,12 @@ function populateXT4Features() {
     return loadFeatureDescriptions('XT4', descriptionsUrl).then(function() {
         console.log('✅ XT4 descriptions loaded successfully');
         console.log('XT4 descriptions count:', Object.keys(window.xt4FeatureDescriptions || {}).length);
+        console.log('XT4 descriptions sample:', Object.keys(window.xt4FeatureDescriptions || {}).slice(0, 5));
         
+        return fetchCsvWithRetry(config.csvUrl, 'XT4 CSV', 3, 1000);
+    }).catch(function(error) {
+        console.error('❌ Failed to load XT4 descriptions:', error);
+        console.log('🔄 Continuing without XT4 descriptions...');
         return fetchCsvWithRetry(config.csvUrl, 'XT4 CSV', 3, 1000);
     }).then(function(csvText) {
         console.log('XT4 CSV fetched successfully, length:', csvText.length, 'characters');
@@ -6810,6 +6815,7 @@ function populateXT4Features() {
                     console.warn('❌ No XT4 placeholder found in HTML block!');
                     console.warn('📝 SOLUTION: Add {xt4 feature checkboxes} to your HTML block field (ID 155)');
                     console.warn('Available placeholders in HTML:', currentHtml.match(/\{[^}]+\}/g) || 'None found');
+                    console.log('🔧 WORKAROUND: Injecting XT4 checkboxes directly into HTML field');
                     htmlBlock.html(html);
                 }
 
@@ -16105,6 +16111,7 @@ $(document).on('click', '.feature-info-icon', function(e) {
 // SIMPLE DESCRIPTION LOOKUP - Shows exactly what's in the CSV files
 function getFeatureDescription(feature, model) {
     var featureUpper = feature.toUpperCase();
+    console.log('🔍 getFeatureDescription called with feature:', feature, 'model:', model);
     
     // 🔧 FIX TYPOS: Correct common misspellings in feature names
     if (featureUpper === 'AUXILIARY TRAILER CAMEREA') {
@@ -16119,6 +16126,7 @@ function getFeatureDescription(feature, model) {
     // If model is specified, try that model's descriptions first
     if (model) {
         var modelDescriptionMap = getModelDescriptionMap(model);
+        console.log('🗺️ Description map for model', model + ':', modelDescriptionMap ? Object.keys(modelDescriptionMap).length + ' descriptions' : 'null/undefined');
         if (modelDescriptionMap && Object.keys(modelDescriptionMap).length > 0) {
             if (modelDescriptionMap[featureUpper]) {
                 description = modelDescriptionMap[featureUpper];

--- a/working code as of july 22nd.html
+++ b/working code as of july 22nd.html
@@ -1067,8 +1067,8 @@ jQuery(document).ready(function($) {
         
         var bestMatch = null;
         var highestSimilarity = 0;
-        // Use lower threshold for Canyon, Sierra 1500, Sierra 2500, CT4, CT4 V-Series, CT5, CT5 V-Series, Escalade, and Escalade ESV descriptions (0.4 vs 0.7)
-        var threshold = (descriptionMap === window.canyonFeatureDescriptions || descriptionMap === window.sierra1500FeatureDescriptions || descriptionMap === window.sierra2500FeatureDescriptions || descriptionMap === window.sierra3500FeatureDescriptions || descriptionMap === window.ct4FeatureDescriptions || descriptionMap === window.ct4VSeriesFeatureDescriptions || descriptionMap === window.ct5FeatureDescriptions || descriptionMap === window.ct5VSeriesFeatureDescriptions || descriptionMap === window.escaladeFeatureDescriptions || descriptionMap === window.escaladeESVFeatureDescriptions) ? 0.4 : 0.7;
+        // Use lower threshold for Canyon, Sierra 1500, Sierra 2500, CT4, CT4 V-Series, CT5, CT5 V-Series, Escalade, Escalade ESV, and XT4 descriptions (0.4 vs 0.7)
+        var threshold = (descriptionMap === window.canyonFeatureDescriptions || descriptionMap === window.sierra1500FeatureDescriptions || descriptionMap === window.sierra2500FeatureDescriptions || descriptionMap === window.sierra3500FeatureDescriptions || descriptionMap === window.ct4FeatureDescriptions || descriptionMap === window.ct4VSeriesFeatureDescriptions || descriptionMap === window.ct5FeatureDescriptions || descriptionMap === window.ct5VSeriesFeatureDescriptions || descriptionMap === window.escaladeFeatureDescriptions || descriptionMap === window.escaladeESVFeatureDescriptions || descriptionMap === window.xt4FeatureDescriptions) ? 0.4 : 0.7;
         
         for (var key in descriptionMap) {
             var similarity = calculateSimilarity(correctedFeature, key);
@@ -1081,9 +1081,9 @@ jQuery(document).ready(function($) {
             }
         }
         
-        // If no match found for Canyon, Sierra 1500, Sierra 2500, CT4, CT4 V-Series, CT5, CT5 V-Series, Escalade, or Escalade ESV and threshold was lowered, try partial word matching
-        if (!bestMatch && (descriptionMap === window.canyonFeatureDescriptions || descriptionMap === window.sierra1500FeatureDescriptions || descriptionMap === window.sierra2500FeatureDescriptions || descriptionMap === window.sierra3500FeatureDescriptions || descriptionMap === window.ct4FeatureDescriptions || descriptionMap === window.ct4VSeriesFeatureDescriptions || descriptionMap === window.ct5FeatureDescriptions || descriptionMap === window.ct5VSeriesFeatureDescriptions || descriptionMap === window.escaladeFeatureDescriptions || descriptionMap === window.escaladeESVFeatureDescriptions)) {
-            var modelName = descriptionMap === window.canyonFeatureDescriptions ? 'Canyon' : (descriptionMap === window.sierra1500FeatureDescriptions ? 'Sierra 1500' : (descriptionMap === window.sierra2500FeatureDescriptions ? 'Sierra 2500' : (descriptionMap === window.sierra3500FeatureDescriptions ? 'Sierra 3500' : (descriptionMap === window.ct4FeatureDescriptions ? 'CT4' : (descriptionMap === window.ct4VSeriesFeatureDescriptions ? 'CT4 V-Series' : (descriptionMap === window.ct5FeatureDescriptions ? 'CT5' : (descriptionMap === window.ct5VSeriesFeatureDescriptions ? 'CT5 V-Series' : (descriptionMap === window.escaladeFeatureDescriptions ? 'Escalade' : 'Escalade ESV'))))))));
+        // If no match found for Canyon, Sierra 1500, Sierra 2500, CT4, CT4 V-Series, CT5, CT5 V-Series, Escalade, Escalade ESV, or XT4 and threshold was lowered, try partial word matching
+        if (!bestMatch && (descriptionMap === window.canyonFeatureDescriptions || descriptionMap === window.sierra1500FeatureDescriptions || descriptionMap === window.sierra2500FeatureDescriptions || descriptionMap === window.sierra3500FeatureDescriptions || descriptionMap === window.ct4FeatureDescriptions || descriptionMap === window.ct4VSeriesFeatureDescriptions || descriptionMap === window.ct5FeatureDescriptions || descriptionMap === window.ct5VSeriesFeatureDescriptions || descriptionMap === window.escaladeFeatureDescriptions || descriptionMap === window.escaladeESVFeatureDescriptions || descriptionMap === window.xt4FeatureDescriptions)) {
+            var modelName = descriptionMap === window.canyonFeatureDescriptions ? 'Canyon' : (descriptionMap === window.sierra1500FeatureDescriptions ? 'Sierra 1500' : (descriptionMap === window.sierra2500FeatureDescriptions ? 'Sierra 2500' : (descriptionMap === window.sierra3500FeatureDescriptions ? 'Sierra 3500' : (descriptionMap === window.ct4FeatureDescriptions ? 'CT4' : (descriptionMap === window.ct4VSeriesFeatureDescriptions ? 'CT4 V-Series' : (descriptionMap === window.ct5FeatureDescriptions ? 'CT5' : (descriptionMap === window.ct5VSeriesFeatureDescriptions ? 'CT5 V-Series' : (descriptionMap === window.escaladeFeatureDescriptions ? 'Escalade' : (descriptionMap === window.escaladeESVFeatureDescriptions ? 'Escalade ESV' : 'XT4')))))))));
             console.log('🔍 Trying partial word matching for ' + modelName + ' feature:', correctedFeature);
             var featureWords = correctedFeature.split(' ').filter(function(w) { return w.length > 3; });
             
@@ -6650,7 +6650,16 @@ function populateXT4Features() {
     console.log('XT4 HTML block found:', htmlBlock.attr('id'));
     console.log('XT4 CSV URL:', config.csvUrl);
 
-    return fetchCsvWithRetry(config.csvUrl, 'XT4 CSV', 3, 1000).then(function(csvText) {
+    // Load XT4 descriptions first
+    var descriptionsUrl = descriptionUrlMap['XT4'];
+    console.log('XT4 descriptions URL:', descriptionsUrl);
+    
+    return loadFeatureDescriptions('XT4', descriptionsUrl).then(function() {
+        console.log('✅ XT4 descriptions loaded successfully');
+        console.log('XT4 descriptions count:', Object.keys(window.xt4FeatureDescriptions || {}).length);
+        
+        return fetchCsvWithRetry(config.csvUrl, 'XT4 CSV', 3, 1000);
+    }).then(function(csvText) {
         console.log('XT4 CSV fetched successfully, length:', csvText.length, 'characters');
         console.log('XT4 CSV first 200 chars:', csvText.substring(0, 200));
         console.log('XT4 CSV first line:', csvText.split('\n')[0]);
@@ -16126,6 +16135,7 @@ function getFeatureDescription(feature, model) {
     
     // Fallback: Try all description sources with direct lookup only
     var allDescriptionSources = [
+        { name: 'XT4', data: typeof window.xt4FeatureDescriptions !== 'undefined' ? window.xt4FeatureDescriptions : {} },
         { name: 'Escalade ESV', data: typeof window.escaladeESVFeatureDescriptions !== 'undefined' ? window.escaladeESVFeatureDescriptions : {} },
         { name: 'Escalade', data: typeof window.escaladeFeatureDescriptions !== 'undefined' ? window.escaladeFeatureDescriptions : {} },
         { name: 'CT5 V-Series', data: typeof window.ct5VSeriesFeatureDescriptions !== 'undefined' ? window.ct5VSeriesFeatureDescriptions : {} },
@@ -16245,6 +16255,8 @@ function getModelDescriptionMap(model) {
         case 'ESCALADE ESV':
         case 'Escalade ESV':
             return window.escaladeESVFeatureDescriptions;
+        case 'XT4':
+            return window.xt4FeatureDescriptions;
         case 'CT4':
             return window.ct4FeatureDescriptions;
         case 'CT4 V-SERIES':

--- a/working code as of july 22nd.html
+++ b/working code as of july 22nd.html
@@ -2916,8 +2916,12 @@ jQuery(document).ready(function($) {
         var featuresToShow = currentFeatures;
         var popupTitle = 'The ' + trimLevel + ' includes all of the following features:';
         
+        console.log('🎯 TRIM WALK: About to show', featuresToShow.length, 'features in popup');
+        console.log('🎯 TRIM WALK: Sample features to show:', featuresToShow.slice(0, 3));
+        
         // Group features by category
         var categorizedFeatures = groupFeaturesByCategory(featuresToShow, modelPrefix);
+        console.log('🎯 TRIM WALK: Categorized features:', Object.keys(categorizedFeatures).length, 'categories');
         
         // Build popup HTML
         var popupHtml = buildTrimWalkPopupHTML(popupTitle, categorizedFeatures, modelPrefix, trimLevel, trimIndex, allTrimLevels, uniqueFeatures);
@@ -3277,7 +3281,8 @@ jQuery(document).ready(function($) {
                     break;
             }
             
-            alternativeNames.forEach(function(altName) {
+            for (var i = 0; i < alternativeNames.length; i++) {
+                var altName = alternativeNames[i];
                 if (window[altName]) {
                     console.log('Found alternative map:', altName);
                     trimLevelMap = window[altName];
@@ -3287,8 +3292,10 @@ jQuery(document).ready(function($) {
                             features.push(feature);
                         }
                     });
+                    console.log('✅ Alternative map processed, found', features.length, 'features for', trimLevel);
+                    break; // Exit the loop after finding and processing the first valid map
                 }
-            });
+            }
         }
         
         return features;
@@ -3312,13 +3319,46 @@ jQuery(document).ready(function($) {
         var featureToCategoryMapName = modelPrefix + 'FeatureToCategoryMap';
         var featureToCategoryMap = window[featureToCategoryMapName];
         
+        if (!featureToCategoryMap) {
+            console.warn('Feature-to-category map not found:', featureToCategoryMapName);
+            
+            // Try alternative map names for special cases
+            var alternativeNames = [];
+            switch(modelPrefix.toLowerCase()) {
+                case 'escaladeesv':
+                    alternativeNames.push('escaladeESVFeatureToCategoryMap');
+                    break;
+                case 'ct4vseries':
+                    alternativeNames.push('ct4VSeriesFeatureToCategoryMap');
+                    break;
+                case 'ct5vseries':
+                    alternativeNames.push('ct5VSeriesFeatureToCategoryMap');
+                    break;
+            }
+            
+            for (var i = 0; i < alternativeNames.length; i++) {
+                if (window[alternativeNames[i]]) {
+                    console.log('Found alternative feature-to-category map:', alternativeNames[i]);
+                    featureToCategoryMap = window[alternativeNames[i]];
+                    break;
+                }
+            }
+        }
+        
         if (featureToCategoryMap) {
             features.forEach(function(feature) {
                 var category = featureToCategoryMap[feature];
                 if (category && categories[category]) {
                     categories[category].push(feature);
+                } else {
+                    // Default to EXTERIOR if no category found
+                    categories['EXTERIOR'].push(feature);
                 }
             });
+        } else {
+            // If no category map found, put all features in EXTERIOR as fallback
+            console.warn('No feature-to-category map found for', modelPrefix, '- defaulting all features to EXTERIOR');
+            categories['EXTERIOR'] = features.slice(); // Copy the array
         }
         
         // Sort features within each category
@@ -3342,6 +3382,12 @@ jQuery(document).ready(function($) {
      * @return {string} HTML for the popup
      */
     function buildTrimWalkPopupHTML(title, categorizedFeatures, modelPrefix, currentTrimLevel, trimIndex, allTrimLevels, uniqueFeatures) {
+        console.log('🏗️ BUILDING TRIM WALK HTML:', currentTrimLevel);
+        console.log('🏗️ Categorized features received:', Object.keys(categorizedFeatures));
+        console.log('🏗️ Total feature count by category:', Object.keys(categorizedFeatures).map(function(cat) {
+            return cat + ': ' + (categorizedFeatures[cat] ? categorizedFeatures[cat].length : 0);
+        }).join(', '));
+        
         var html = '<div class="trim-walk-popup-content">';
         
         // Add header with title and navigation buttons side by side

--- a/working code as of july 22nd.html
+++ b/working code as of july 22nd.html
@@ -6651,12 +6651,18 @@ function populateXT4Features() {
     console.log('XT4 CSV URL:', config.csvUrl);
 
     return fetchCsvWithRetry(config.csvUrl, 'XT4 CSV', 3, 1000).then(function(csvText) {
-        console.log('XT4 CSV fetched successfully, length:', csvText.length, 'characters, first 100 chars:', csvText.substring(0, 100));
+        console.log('XT4 CSV fetched successfully, length:', csvText.length, 'characters');
+        console.log('XT4 CSV first 200 chars:', csvText.substring(0, 200));
+        console.log('XT4 CSV first line:', csvText.split('\n')[0]);
+        console.log('XT4 CSV second line:', csvText.split('\n')[1]);
 
         return new Promise(function(resolve, reject) {
             Papa.parse(csvText, {
                 header: false,
                 skipEmptyLines: true,
+                delimiter: ',',
+                quoteChar: '"',
+                escapeChar: '"',
                 complete: function(results) {
                 console.log('XT4 CSV parsed, rows:', results.data.length);
                 console.log('First 10 rows of parsed data:', results.data.slice(0, 10));

--- a/working code as of july 22nd.html
+++ b/working code as of july 22nd.html
@@ -1056,8 +1056,8 @@ jQuery(document).ready(function($) {
         
         var bestMatch = null;
         var highestSimilarity = 0;
-        // Use lower threshold for Canyon, Sierra 1500, Sierra 2500, CT4, CT4 V-Series, CT5, and CT5 V-Series descriptions (0.4 vs 0.7)
-        var threshold = (descriptionMap === window.canyonFeatureDescriptions || descriptionMap === window.sierra1500FeatureDescriptions || descriptionMap === window.sierra2500FeatureDescriptions || descriptionMap === window.sierra3500FeatureDescriptions || descriptionMap === window.ct4FeatureDescriptions || descriptionMap === window.ct4VSeriesFeatureDescriptions || descriptionMap === window.ct5FeatureDescriptions || descriptionMap === window.ct5VSeriesFeatureDescriptions) ? 0.4 : 0.7;
+        // Use lower threshold for Canyon, Sierra 1500, Sierra 2500, CT4, CT4 V-Series, CT5, CT5 V-Series, Escalade, and Escalade ESV descriptions (0.4 vs 0.7)
+        var threshold = (descriptionMap === window.canyonFeatureDescriptions || descriptionMap === window.sierra1500FeatureDescriptions || descriptionMap === window.sierra2500FeatureDescriptions || descriptionMap === window.sierra3500FeatureDescriptions || descriptionMap === window.ct4FeatureDescriptions || descriptionMap === window.ct4VSeriesFeatureDescriptions || descriptionMap === window.ct5FeatureDescriptions || descriptionMap === window.ct5VSeriesFeatureDescriptions || descriptionMap === window.escaladeFeatureDescriptions || descriptionMap === window.escaladeESVFeatureDescriptions) ? 0.4 : 0.7;
         
         for (var key in descriptionMap) {
             var similarity = calculateSimilarity(correctedFeature, key);
@@ -1070,9 +1070,9 @@ jQuery(document).ready(function($) {
             }
         }
         
-        // If no match found for Canyon, Sierra 1500, Sierra 2500, CT4, CT4 V-Series, CT5, or CT5 V-Series and threshold was lowered, try partial word matching
-        if (!bestMatch && (descriptionMap === window.canyonFeatureDescriptions || descriptionMap === window.sierra1500FeatureDescriptions || descriptionMap === window.sierra2500FeatureDescriptions || descriptionMap === window.sierra3500FeatureDescriptions || descriptionMap === window.ct4FeatureDescriptions || descriptionMap === window.ct4VSeriesFeatureDescriptions || descriptionMap === window.ct5FeatureDescriptions || descriptionMap === window.ct5VSeriesFeatureDescriptions)) {
-            var modelName = descriptionMap === window.canyonFeatureDescriptions ? 'Canyon' : (descriptionMap === window.sierra1500FeatureDescriptions ? 'Sierra 1500' : (descriptionMap === window.sierra2500FeatureDescriptions ? 'Sierra 2500' : (descriptionMap === window.sierra3500FeatureDescriptions ? 'Sierra 3500' : (descriptionMap === window.ct4FeatureDescriptions ? 'CT4' : (descriptionMap === window.ct4VSeriesFeatureDescriptions ? 'CT4 V-Series' : (descriptionMap === window.ct5FeatureDescriptions ? 'CT5' : 'CT5 V-Series'))))));
+        // If no match found for Canyon, Sierra 1500, Sierra 2500, CT4, CT4 V-Series, CT5, CT5 V-Series, Escalade, or Escalade ESV and threshold was lowered, try partial word matching
+        if (!bestMatch && (descriptionMap === window.canyonFeatureDescriptions || descriptionMap === window.sierra1500FeatureDescriptions || descriptionMap === window.sierra2500FeatureDescriptions || descriptionMap === window.sierra3500FeatureDescriptions || descriptionMap === window.ct4FeatureDescriptions || descriptionMap === window.ct4VSeriesFeatureDescriptions || descriptionMap === window.ct5FeatureDescriptions || descriptionMap === window.ct5VSeriesFeatureDescriptions || descriptionMap === window.escaladeFeatureDescriptions || descriptionMap === window.escaladeESVFeatureDescriptions)) {
+            var modelName = descriptionMap === window.canyonFeatureDescriptions ? 'Canyon' : (descriptionMap === window.sierra1500FeatureDescriptions ? 'Sierra 1500' : (descriptionMap === window.sierra2500FeatureDescriptions ? 'Sierra 2500' : (descriptionMap === window.sierra3500FeatureDescriptions ? 'Sierra 3500' : (descriptionMap === window.ct4FeatureDescriptions ? 'CT4' : (descriptionMap === window.ct4VSeriesFeatureDescriptions ? 'CT4 V-Series' : (descriptionMap === window.ct5FeatureDescriptions ? 'CT5' : (descriptionMap === window.ct5VSeriesFeatureDescriptions ? 'CT5 V-Series' : (descriptionMap === window.escaladeFeatureDescriptions ? 'Escalade' : 'Escalade ESV'))))))));
             console.log('🔍 Trying partial word matching for ' + modelName + ' feature:', correctedFeature);
             var featureWords = correctedFeature.split(' ').filter(function(w) { return w.length > 3; });
             
@@ -2855,6 +2855,8 @@ jQuery(document).ready(function($) {
         
         // Get ALL features for this trim level
         var currentFeatures = getTrimLevelFeatures(trimLevel, modelPrefix);
+        console.log('📋 TRIM WALK: Features for ' + trimLevel + ' (' + modelPrefix + '):', currentFeatures.length, 'features');
+        console.log('📋 TRIM WALK: Sample features:', currentFeatures.slice(0, 5));
         
         // FIX: Ensure allTrimLevels is properly passed and not empty
         if (!allTrimLevels || allTrimLevels.length === 0) {
@@ -2939,6 +2941,8 @@ jQuery(document).ready(function($) {
         var featureDescriptions = {};
         var modelName = '';
         
+        console.log('🔍 TRIM WALK: Getting feature descriptions for model prefix:', modelPrefix);
+        
         switch(modelPrefix.toLowerCase()) {
             case 'terrain':
                 featureDescriptions = window.terrainFeatureDescriptions;
@@ -2993,6 +2997,7 @@ jQuery(document).ready(function($) {
             case 'escaladeesv':
                 featureDescriptions = window.escaladeESVFeatureDescriptions;
                 modelName = 'Escalade ESV';
+                console.log('🔍 TRIM WALK: Escalade ESV descriptions found:', Object.keys(featureDescriptions || {}).length, 'descriptions');
                 break;
             default:
                 console.warn('Unknown model prefix for trim walk popup:', modelPrefix);
@@ -6254,6 +6259,13 @@ function populateEscaladeFeatures() {
 // Cadillac Escalade ESV population function
 function populateEscaladeESVFeatures() {
     console.log('=== populateEscaladeESVFeatures called ===');
+    
+    // FORCE CLEAR ANY CACHED DATA FOR ESCALADE ESV
+    console.log('🧹 CLEARING ESCALADE ESV CACHED DATA...');
+    window.escaladeESVFeatureMap = {};
+    window.escaladeESVTrimLevelMap = {};
+    window.escaladeESVFeatureToCategoryMap = {};
+    
     console.log('Current escaladeESVPopulated flag:', escaladeESVPopulated);
     console.log('Form ID:', formId);
     console.log('escaladeESVHtmlBlockFieldId:', escaladeESVHtmlBlockFieldId);
@@ -9850,9 +9862,15 @@ function processEscaladeESVTrimLevels(csvData, selectedFeatures, htmlBlock, trim
 					var config = modelConfigs[model];
 					var correctModelFilter = config ? config.modelFilter : 'Escalade ESV';
 					console.log('🔵 Opening Escalade ESV trim popup for:', correctModelFilter);
+					
+					// Reset the flag before calling showTrimLevelsPopup to prevent conflicts
+					window.escaladeESVTrimPopupOpening = false;
+					
 					showTrimLevelsPopup(model, matchingTrimLevels, correctModelFilter);
 				} else {
 					alert('No matching trim levels found for the selected features.');
+					// Reset the flag on error
+					window.escaladeESVTrimPopupOpening = false;
 				}
 				
 				// Reset the flag after a delay
@@ -15561,6 +15579,7 @@ function convertModelPrefixToDescriptionKey(modelPrefix) {
         'sierra2500': 'SIERRA 2500', 
         'sierra3500': 'SIERRA 3500',
         'escalade': 'ESCALADE',
+        'escaladeesv': 'ESCALADE ESV',
         'terrain': 'TERRAIN',
         'acadia': 'ACADIA',
         'yukon': 'YUKON',

--- a/working code as of july 22nd.html
+++ b/working code as of july 22nd.html
@@ -12545,6 +12545,7 @@ function initFormBindings() {
     if (!model) {
         console.error('showTrimLevelsPopup: model parameter is required');
         alert('Error: Model information is missing. Please refresh the page and try again.');
+        window.trimPopupCreating = false; // Reset flag on error
         return;
     }
     
@@ -12566,6 +12567,7 @@ function initFormBindings() {
         }
         
         alert('Error: No trim levels available for ' + modelName + '. Please select some features first.');
+        window.trimPopupCreating = false; // Reset flag on error
         return;
     }
     
@@ -12589,6 +12591,7 @@ function initFormBindings() {
                         rawContent: csvText.substring(0, 500)
                     });
                     alert('Error: New inventory data is empty or missing required columns (Series, Model). Please verify the CSV file at ' + csvUrl + ' or contact support.');
+                    window.trimPopupCreating = false; // Reset flag on error
                     return;
                 }
 
@@ -12909,11 +12912,13 @@ function initFormBindings() {
             error: function(error) {
                 console.error('Papa Parse error for New Inventory CSV: ' + error);
                 alert('Error: Failed to parse new inventory data. Please contact support.');
+                window.trimPopupCreating = false; // Reset flag on error
             }
         });
     }).catch(function(error) {
         console.error('Fetch error for New Inventory CSV: ' + error.message);
         alert('Error: Unable to load new inventory data. Please check the CSV file at ' + csvUrl + ' or contact support.');
+        window.trimPopupCreating = false; // Reset flag on error
     });
 }
 
@@ -14696,7 +14701,62 @@ window.findSierra2500HtmlBlock = function() {
     return htmlBlock.length > 0;
 };
 
-console.log('Debug functions available: testTerrainDebug(), forcePopulateTerrainFeatures(), createTerrainCheckboxesManually(), checkTerrainState(), testSierra2500Debug(), forceSierra2500Populate(), findSierra2500HtmlBlock()');
+console.log('Debug functions available: testTerrainDebug(), forcePopulateTerrainFeatures(), createTerrainCheckboxesManually(), checkTerrainState(), testSierra2500Debug(), forceSierra2500Populate(), findSierra2500HtmlBlock(), resetAllGlobalFlags(), emergencyCleanupPopupFlags()');
+
+// Function to reset all global popup and model state flags
+function resetAllGlobalFlags() {
+    console.log('🧹 Resetting all global state flags for model switching...');
+    
+    // Reset popup creation flags
+    window.trimPopupCreating = false;
+    window.trimPopupClosing = false;
+    window.escaladeTrimPopupOpening = false;
+    
+    // Reset any existing popups
+    $('#trimLevelsPopup, #trimLevelsOverlay, #vehiclePopup, #overlay, #notePopup, #noteOverlay, #featurePopup, #featureOverlay').remove();
+    
+    // Reset processing flags
+    window.isProcessingClick = false;
+    
+    console.log('✅ All global state flags reset');
+}
+
+// Emergency cleanup function for stuck popup states
+function emergencyCleanupPopupFlags() {
+    console.log('🚨 EMERGENCY CLEANUP: Resetting all popup flags and removing popups...');
+    
+    // Force reset all flags
+    window.trimPopupCreating = false;
+    window.trimPopupClosing = false;
+    window.escaladeTrimPopupOpening = false;
+    window.isProcessingClick = false;
+    
+    // Force remove all popups
+    $('#trimLevelsPopup, #trimLevelsOverlay, #vehiclePopup, #overlay, #notePopup, #noteOverlay, #featurePopup, #featureOverlay').remove();
+    
+    console.log('✅ Emergency cleanup completed');
+}
+
+// Safety mechanism: Reset stuck flags after 10 seconds if they're still set
+setInterval(function() {
+    var hasStuckFlags = window.trimPopupCreating || window.trimPopupClosing || window.escaladeTrimPopupOpening;
+    
+    if (hasStuckFlags) {
+        console.log('⚠️ SAFETY CHECK: Detected stuck popup flags, performing cleanup...');
+        console.log('  - trimPopupCreating:', window.trimPopupCreating);
+        console.log('  - trimPopupClosing:', window.trimPopupClosing);
+        console.log('  - escaladeTrimPopupOpening:', window.escaladeTrimPopupOpening);
+        
+        // Check if there are actually any visible popups
+        var visiblePopups = $('#trimLevelsPopup, #vehiclePopup, #notePopup, #featurePopup').length;
+        
+        if (visiblePopups === 0) {
+            // No visible popups but flags are set - reset them
+            console.log('🔧 SAFETY FIX: No visible popups found, resetting stuck flags');
+            emergencyCleanupPopupFlags();
+        }
+    }
+}, 10000); // Check every 10 seconds
 
 // GLOBAL RADIO BUTTON LISTENER FOR DEBUGGING
 $(document).on('change', 'input[type="radio"]', function() {
@@ -14707,6 +14767,11 @@ $(document).on('change', 'input[type="radio"]', function() {
     console.log('  - Checked:', $(this).is(':checked'));
     console.log('  - Expected GMC field pattern:', 'choice_' + formId + '_' + gmcModelFieldId);
     console.log('  - Matches pattern:', $(this).attr('id') && $(this).attr('id').indexOf('choice_' + formId + '_' + gmcModelFieldId) !== -1);
+    
+    // Reset all global state flags when switching models to prevent conflicts
+    if ($(this).is(':checked')) {
+        resetAllGlobalFlags();
+    }
     
     if ($(this).val() === 'TERRAIN' && $(this).is(':checked')) {
         console.log('🚨 TERRAIN DETECTED IN GLOBAL LISTENER - FORCING POPULATE');

--- a/working code as of july 22nd.html
+++ b/working code as of july 22nd.html
@@ -2408,6 +2408,7 @@ jQuery(document).ready(function($) {
         }).catch(function(error) {
             console.error('Fetch error for Cadillac XT4 Feature Descriptions:', error.message);
             window.xt4FeatureDescriptions = {};
+            return Promise.resolve(); // Ensure we return a resolved Promise even on error
         });
     }
 

--- a/working code as of july 22nd.html
+++ b/working code as of july 22nd.html
@@ -3259,6 +3259,19 @@ jQuery(document).ready(function($) {
                 modelPrefix.charAt(0).toUpperCase() + modelPrefix.slice(1).toLowerCase() + 'TrimLevelMap'
             ];
             
+            // Handle special cases for variable name mapping
+            switch(modelPrefix.toLowerCase()) {
+                case 'escaladeesv':
+                    alternativeNames.unshift('escaladeESVTrimLevelMap');
+                    break;
+                case 'ct4vseries':
+                    alternativeNames.unshift('ct4VSeriesTrimLevelMap');
+                    break;
+                case 'ct5vseries':
+                    alternativeNames.unshift('ct5VSeriesTrimLevelMap');
+                    break;
+            }
+            
             alternativeNames.forEach(function(altName) {
                 if (window[altName]) {
                     console.log('Found alternative map:', altName);
@@ -10139,6 +10152,29 @@ function processEscaladeESVTrimLevels(csvData, selectedFeatures, htmlBlock, trim
         
         htmlBlock = $('#field_' + formId + '_' + htmlBlockFieldId);
         trimLevelsButtonBlock = $('#field_' + formId + '_' + trimLevelsButtonFieldId);
+    } else if (model === 'ESCALADE ESV' || model === 'Escalade ESV') {
+        // For ESCALADE ESV, checkboxes are in field 154 (HTML block)
+        checkboxField = $('#field_' + formId + '_' + escaladeESVHtmlBlockFieldId);
+        if (!checkboxField.length) {
+            checkboxField = $('#field_' + formId + '_154');
+        }
+        if (!checkboxField.length) {
+            checkboxField = $('[id*="154"]').filter(function() {
+                return $(this).attr('id').includes('field') || $(this).attr('id').includes('input');
+            });
+        }
+        
+        console.log('ESCALADE ESV checkboxField debug:', {
+            escaladeESVHtmlBlockFieldId: escaladeESVHtmlBlockFieldId,
+            selector1: '#field_' + formId + '_' + escaladeESVHtmlBlockFieldId,
+            selector2: '#field_' + formId + '_154',
+            found: checkboxField.length,
+            actualId: checkboxField.attr('id'),
+            hasCheckboxes: checkboxField.find('input[type="checkbox"]').length
+        });
+        
+        htmlBlock = $('#field_' + formId + '_' + htmlBlockFieldId);
+        trimLevelsButtonBlock = $('#field_' + formId + '_' + trimLevelsButtonFieldId);
     } else {
         // For other models, checkboxes are in their respective fields
         checkboxField = $('#field_' + formId + '_' + config.fieldId);
@@ -10150,7 +10186,7 @@ function processEscaladeESVTrimLevels(csvData, selectedFeatures, htmlBlock, trim
     var defaultButtonText = '<button id="viewTrimLevelsButton">View Trim Levels</button>';
     var noMatchText = 'No matching trim levels found. Please adjust your feature selections or contact support.';
 
-    console.log('Checking ' + model + ' checkbox field (ID: ' + (model === 'TERRAIN' ? terrainHtmlBlockFieldId : model === 'ACADIA' ? acadiaHtmlBlockFieldId : model === 'YUKON' ? yukonHtmlBlockFieldId : model === 'CANYON' ? canyonHtmlBlockFieldId : model === 'SIERRA 1500' ? sierra1500HtmlBlockFieldId : (model === 'SIERRA 2500' || model === 'SIERRA 2500HD') ? sierra2500HtmlBlockFieldId : (model === 'SIERRA 3500' || model === 'SIERRA 3500HD') ? sierra3500HtmlBlockFieldId : model === 'CT4' ? ct4HtmlBlockFieldId : model === 'CT4 V-SERIES' ? ct4VSeriesHtmlBlockFieldId : model === 'CT5' ? ct5HtmlBlockFieldId : model === 'CT5 V-SERIES' ? ct5VSeriesHtmlBlockFieldId : model === 'ESCALADE' ? escaladeHtmlBlockFieldId : config.fieldId) + '):', {
+    console.log('Checking ' + model + ' checkbox field (ID: ' + (model === 'TERRAIN' ? terrainHtmlBlockFieldId : model === 'ACADIA' ? acadiaHtmlBlockFieldId : model === 'YUKON' ? yukonHtmlBlockFieldId : model === 'CANYON' ? canyonHtmlBlockFieldId : model === 'SIERRA 1500' ? sierra1500HtmlBlockFieldId : (model === 'SIERRA 2500' || model === 'SIERRA 2500HD') ? sierra2500HtmlBlockFieldId : (model === 'SIERRA 3500' || model === 'SIERRA 3500HD') ? sierra3500HtmlBlockFieldId : model === 'CT4' ? ct4HtmlBlockFieldId : model === 'CT4 V-SERIES' ? ct4VSeriesHtmlBlockFieldId : model === 'CT5' ? ct5HtmlBlockFieldId : model === 'CT5 V-SERIES' ? ct5VSeriesHtmlBlockFieldId : model === 'ESCALADE' ? escaladeHtmlBlockFieldId : (model === 'ESCALADE ESV' || model === 'Escalade ESV') ? escaladeESVHtmlBlockFieldId : config.fieldId) + '):', {
         fieldExists: checkboxField.length > 0,
         fieldVisible: checkboxField.is(':visible'),
         fieldClasses: checkboxField.attr('class'),
@@ -10436,7 +10472,7 @@ function processEscaladeESVTrimLevels(csvData, selectedFeatures, htmlBlock, trim
         showFeatureDescription(feature, description);
     });
 
-    if (!checkboxField.length || (model !== 'K5' && model !== 'TERRAIN' && model !== 'ACADIA' && model !== 'YUKON' && model !== 'CANYON' && model !== 'SIERRA 1500' && model !== 'SIERRA 2500' && model !== 'SIERRA 2500HD' && model !== 'SIERRA 3500' && model !== 'SIERRA 3500HD' && model !== 'CT4' && !checkboxField.is(':visible'))) {
+    if (!checkboxField.length || (model !== 'K5' && model !== 'TERRAIN' && model !== 'ACADIA' && model !== 'YUKON' && model !== 'CANYON' && model !== 'SIERRA 1500' && model !== 'SIERRA 2500' && model !== 'SIERRA 2500HD' && model !== 'SIERRA 3500' && model !== 'SIERRA 3500HD' && model !== 'CT4' && model !== 'CT4 V-SERIES' && model !== 'CT5' && model !== 'CT5 V-SERIES' && model !== 'ESCALADE' && model !== 'Escalade' && model !== 'ESCALADE ESV' && model !== 'Escalade ESV' && !checkboxField.is(':visible'))) {
         console.log(model + ' checkbox field not found or not visible, resetting HTML block');
         if (htmlBlock.length) {
             htmlBlock.find('p').text(defaultText);


### PR DESCRIPTION
Fixes trim level popup reusability and model switching by ensuring global state flags are properly reset on error, model change, and via a periodic cleanup.

The previous implementation had several code paths where popup-related flags (`window.trimPopupCreating`, `window.escaladeTrimPopupOpening`) were not reset upon early exit or error, leading to the "View Available Trim Levels" button becoming unresponsive and the application freezing when switching between vehicle models. This PR adds explicit flag resets in all error/exit paths and introduces a comprehensive global state reset function called on model changes, along with a periodic safety cleanup.

---
<a href="https://cursor.com/background-agent?bcId=bc-e24b2ec8-a340-48aa-9ae0-96d01981fa81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e24b2ec8-a340-48aa-9ae0-96d01981fa81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

